### PR TITLE
Toggle plf

### DIFF
--- a/Simulation_engine/agg_pop.py
+++ b/Simulation_engine/agg_pop.py
@@ -1,4 +1,3 @@
-
 import pandas  # type: ignore
 import os
 import math
@@ -279,7 +278,7 @@ def test_h5_input(
     name_variables=("rfr", "irpp", "nbptr"),
     aggfunc="sum",
     compdic=None,
-    is_plf=False
+    is_plf=False,
 ):
     PERIOD = "2018"
     TBS = TBS_PLF if is_plf else FranceTaxBenefitSystem()
@@ -290,7 +289,9 @@ def test_h5_input(
     )
     if aggfunc == "sum":  # Pour la somme, on calcule les % d'erreur sur la répartition.
         testerrorvalues(df)
-    aggs_to_compute = ["wprm", "salaire_de_base", "retraite_brute"] + list(name_variables)
+    aggs_to_compute = ["wprm", "salaire_de_base", "retraite_brute"] + list(
+        name_variables
+    )
     val_donnees_pac_agg = 0
     trpac_agg = [
         compdic[ag]
@@ -598,7 +599,7 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=False
+        is_plf=False,
     )
     print("after adj 2 :")
     test_h5_input(
@@ -606,7 +607,7 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=False
+        is_plf=False,
     )
 
     print("WITH PLF NOW HIhihi")
@@ -616,7 +617,7 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=True
+        is_plf=True,
     )
     print("after adj 2 plf:")
     test_h5_input(
@@ -624,8 +625,9 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=True
+        is_plf=True,
     )
+
 
 # ToDo : Le test doit retourner True si :
 #  - On a Une erreur totale sur la distrib de rfr < 2.5% après ajustement

--- a/Simulation_engine/agg_pop.py
+++ b/Simulation_engine/agg_pop.py
@@ -1,9 +1,12 @@
 import pandas  # type: ignore
-import os
 import math
 
 from openfisca_france import FranceTaxBenefitSystem  # type: ignore
-from simulate_pop_from_reform import simulation, TBS_PLF  # type: ignore
+from Simulation_engine.simulate_pop_from_reform import (
+    simulation,
+    TBS_DEFAULT,
+    annee_de_calcul,
+)  # type: ignore
 
 
 def aggregats_ff(
@@ -182,8 +185,10 @@ def compare_input_data(
     input_h5="./Simulation_engine/dummy_data.h5",
     input_h5_b="./Simulation_engine/dummy_data.h5",
     name_variables=("rfr", "irpp", "nbptr"),
+    PERIOD=None,
 ):
-    PERIOD = "2018"
+    if PERIOD is None:
+        PERIOD = annee_de_calcul
     TBS = FranceTaxBenefitSystem()
     DUMMY_DATA = pandas.read_hdf(input_h5)
     simulation_base_deciles, dictionnaire_datagrouped = simulation(
@@ -209,10 +214,12 @@ def test_useless_variables(
     input_h5="./Simulation_engine/dummy_data.h5",
     outfile_path=None,
     name_variables=("rfr", "irpp", "nbptr"),
+    PERIOD=None,
 ):
+    if PERIOD is None:
+        PERIOD = annee_de_calcul
     pandas.options.mode.chained_assignment = None
     list_useless_variables = []
-    PERIOD = "2018"
     TBS = FranceTaxBenefitSystem()
     DUMMY_DATA = pandas.read_hdf(input_h5)
     simulation_base_deciles, dictionnaire_datagrouped = simulation(
@@ -279,9 +286,11 @@ def test_h5_input(
     aggfunc="sum",
     compdic=None,
     is_plf=False,
+    PERIOD=None,
 ):
-    PERIOD = "2018"
-    TBS = TBS_PLF if is_plf else FranceTaxBenefitSystem()
+    if PERIOD is None:
+        PERIOD = annee_de_calcul
+    TBS = TBS_DEFAULT["plf"] if is_plf else FranceTaxBenefitSystem()
     DUMMY_DATA = pandas.read_hdf(input_h5)
     simulation_base_deciles = simulation(PERIOD, DUMMY_DATA, TBS)
     df = aggregats_ff(PERIOD, simulation_base_deciles, name_variables).sort_values(
@@ -349,9 +358,10 @@ def ajustement_h5(
     input_h5="./Simulation_engine/dummy_data.h5",
     output_h5="./Simulation_engine/dummy_data_ajuste.h5",
     distribution_rfr_population="./Simulation_engine/Calib/ResFinalCalibSenat.csv",
+    PERIOD=None,
 ):
-    print("puréé", os.listdir("."))
-    PERIOD = "2018"
+    if PERIOD is None:
+        PERIOD = annee_de_calcul
     ajuste_h5 = output_h5
     TBS = FranceTaxBenefitSystem()
     DUMMY_DATA = pandas.read_hdf(input_h5)

--- a/Simulation_engine/reformePLF.py
+++ b/Simulation_engine/reformePLF.py
@@ -1,4 +1,3 @@
-
 reforme_base = {
     "impot_revenu": {
         "bareme": {
@@ -88,7 +87,7 @@ only_reforme = {
 }
 
 
-reformePLF = {
+reforme_PLF_2020 = {
     "impot_revenu": {
         "bareme": {
             "seuils": [10064, 25659, 73369, 157806],

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -207,7 +207,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
                 0
             ].calculate("rfr", period)
 
-    for nom_res_base in TBS_DEFAULT:
+    for nom_res_base in list(TBS_DEFAULT.keys()) + ['apres']:
         res[nom_res_base] = -(
             impots_par_reforme[nom_res_base] * impots_par_reforme["wprm"]
         ).sum()
@@ -259,7 +259,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
             # empiric = valeur de base sur laquelle calibrer (pour prendre en compte, par
             # exemple les crédits d'impôts. Représente le montant total d'IR récolté l'année
             # prochaine dans le scénario "avant" (i.e. avec le code existant))
-            empiric = 66.9 * 10 ** 9
+            empiric = 66900 * 10 ** 6
             factor = adjustment(empiric, total)
             total = adjust_total(factor, total)
             deciles: Deciles = adjust_deciles(factor, decdiffres)

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -28,6 +28,18 @@ version_beta_sans_simu_pop = (
 )  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
 adjust_results = True
 
+# Decrit les réformes renvoyées par défaut.
+# Vide en l'absence de PLF, si un PLF survient on peut le renseigner
+# Toutes les requêtes renvoient un résultat "avant" (code existant),
+# un résultat "apres" (reforme renseignée dans la requete)
+# et un résultat par réforme présente dans reformes_par_defaut
+reformes_par_defaut: Dict[str, Dict] = {}
+# from Simulation_engine.reformePLF import reforme_PLF_2020
+# reformes_par_defaut["plf"] = reforme_PLF_2020  Ca c'était le PLF 2020. Moins intéressant depuis qu'il est la loi
+
+# Année sur la législation de laquelle les calculs seront menés.
+annee_de_calcul = 2020
+
 # Types
 Total = Dict[str, float]
 Deciles = List[Dict[str, float]]
@@ -355,12 +367,12 @@ def scenar_values(
     df = calcule_maillage_intervalle(
         var_brute, minv, maxv, pourcentage_hausse, valeur_hausse
     )
-    PERIOD = "2018"
+    PERIOD = str(annee_de_calcul)
     TBS = FranceTaxBenefitSystem()
     # définit un ménage par ligne
     sim = simulation(PERIOD, df, TBS)
     net = var_nette
-    df[net] = sim[0].calculate_add(net, "2018")
+    df[net] = sim[0].calculate_add(net, PERIOD)
     return df[[var_brute, var_nette]]
 
 
@@ -422,7 +434,7 @@ conversion_variables["retraite_brute_to_retraite_imposable"] = scenar_values(
 )
 
 
-PERIOD = "2018"
+PERIOD = str(annee_de_calcul)
 TBS = FranceTaxBenefitSystem()
 TBS_PLF = IncomeTaxReform(TBS, reformePLF, PERIOD)
 CAS_TYPE = load_data("DCT.csv")

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -362,7 +362,7 @@ def calcule_maillage_intervalle(
 
 
 def scenar_values(
-    minv, maxv, var_brute, var_nette, pourcentage_hausse=0.01, valeur_hausse=100
+    minv, maxv, var_brute, var_nette, pourcentage_hausse=0.001, valeur_hausse=100
 ):
     """
     Calcule les valeurs de var_nette pour var_brute dans [minv, maxv]

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -27,6 +27,8 @@ version_beta_sans_simu_pop = (
 )  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
 adjust_results = True
 
+#  PARTIE CONFIGURABLE PAR L'UTILISATEUR
+
 # Decrit les réformes renvoyées par défaut.
 # Vide en l'absence de PLF, si un PLF survient on peut le renseigner
 # Toutes les requêtes renvoient un résultat "avant" (code existant),
@@ -39,6 +41,7 @@ reformes_par_defaut: Dict[str, Dict] = {}
 # Année sur la législation de laquelle les calculs seront menés.
 annee_de_calcul = 2020
 
+# FIN DE LA PARTIE CONFIGURABLE PAR L'UTILISATEUR
 # Types
 Total = Dict[str, float]
 Deciles = List[Dict[str, float]]

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -207,11 +207,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
                 0
             ].calculate("rfr", period)
 
-    for nom_res_base in [
-        colonne_df
-        for colonne_df in impots_par_reforme.columns
-        if colonne_df not in ["rfr", "wprm"]
-    ]:
+    for nom_res_base in TBS_DEFAULT:
         res[nom_res_base] = -(
             impots_par_reforme[nom_res_base] * impots_par_reforme["wprm"]
         ).sum()

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -42,6 +42,13 @@ reformes_par_defaut: Dict[str, Dict] = {}
 annee_de_calcul = 2020
 
 # FIN DE LA PARTIE CONFIGURABLE PAR L'UTILISATEUR
+
+# liste_noms_reformes_sans_apres contient les noms de réformes hormis celle demandée par l'usager :
+liste_noms_reformes_sans_apres = sorted(list(reformes_par_defaut.keys()) + ["avant"])
+# liste_noms_reformes_avec_apres contient les noms de réformes incluant celle demandée par l'usager :
+liste_noms_reformes_avec_apres = liste_noms_reformes_sans_apres + ["apres"]
+
+
 # Types
 Total = Dict[str, float]
 Deciles = List[Dict[str, float]]
@@ -145,9 +152,7 @@ def simulation(period, data, tbs):
 
 def calcule_personnes_touchees(impots_par_reforme):
     # On fait tous les passages possibles entre les resultats:
-    simus_passages = sorted(list(TBS_DEFAULT.keys())) + [
-        "apres"
-    ]  # ["avant", "plf", "apres"]
+    simus_passages = liste_noms_reformes_avec_apres
     transcription_code = ["neutre", "gagnant", "perdant_zero", "neutre_zero", "perdant"]
     foyers_fiscaux_touches: Dict[str, Dict[str, int]] = {}
     IMPOT_DIMINUE = 1
@@ -210,7 +215,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
                 0
             ].calculate("rfr", period)
 
-    for nom_res_base in list(TBS_DEFAULT.keys()) + ['apres']:
+    for nom_res_base in liste_noms_reformes_avec_apres:
         res[nom_res_base] = -(
             impots_par_reforme[nom_res_base] * impots_par_reforme["wprm"]
         ).sum()
@@ -221,7 +226,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         # dans le cas d'un compare avec isdecile = True)
         frontieres_deciles: List[float] = []
         noms_simus = list(
-            set(dictionnaire_simulations.keys()) | set(TBS_DEFAULT.keys())
+            set(dictionnaire_simulations.keys()) | set(liste_noms_reformes_sans_apres)
         )
         totweight = impots_par_reforme["wprm"].sum()
         nbd = 10
@@ -489,7 +494,7 @@ else:
         ][0].calculate("irpp", PERIOD)
 # simulation_base_castypes = simulation(PERIOD, CAS_TYPE, TBS)
 simulations_reformes_par_defaut_castypes = {}
-for nom_reforme in TBS_DEFAULT:
+for nom_reforme in liste_noms_reformes_sans_apres:
     simulations_reformes_par_defaut_castypes[nom_reforme] = simulation(
         PERIOD, CAS_TYPE, TBS_DEFAULT[nom_reforme]
     )

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -15,12 +15,17 @@ from dotenv import load_dotenv
 
 load_dotenv(dotenv_path=".env")
 
+
+# Config
+
 data_path = os.getenv("DATA_PATH")  # type: Optional[str]
 nom_table_resultats_base = os.getenv("NAME_TABLE_BASE_RESULT")  # type: Optional[str]
 if nom_table_resultats_base is None:
     nom_table_resultats_base = "base_results"
-# Config
-version_beta_sans_simu_pop = False
+
+version_beta_sans_simu_pop = (
+    data_path is None
+)  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
 adjust_results = True
 
 # Types

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -1,4 +1,4 @@
-from functools import partial
+# from functools import partial
 from typing import Dict, List, Optional
 import os
 
@@ -9,7 +9,6 @@ from openfisca_core.simulation_builder import SimulationBuilder  # type: ignore
 from openfisca_france import FranceTaxBenefitSystem  # type: ignore
 from models import from_postgres
 from Simulation_engine.reforms import IncomeTaxReform
-from Simulation_engine.reformePLF import reformePLF
 from Simulation_engine.non_cached_variables import non_cached_variables
 from dotenv import load_dotenv
 

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -263,7 +263,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
             # empiric = valeur de base sur laquelle calibrer (pour prendre en compte, par
             # exemple les crédits d'impôts. Représente le montant total d'IR récolté l'année
             # prochaine dans le scénario "avant" (i.e. avec le code existant))
-            empiric = 73 * 10 ** 9
+            empiric = 66.9 * 10 ** 9
             factor = adjustment(empiric, total)
             total = adjust_total(factor, total)
             deciles: Deciles = adjust_deciles(factor, decdiffres)

--- a/scripts/generate_default_results.py
+++ b/scripts/generate_default_results.py
@@ -1,8 +1,7 @@
 from Simulation_engine.simulate_pop_from_reform import (
     simulation,
     PERIOD,
-    TBS,
-    TBS_PLF,
+    TBS_DEFAULT,
     DUMMY_DATA,
 )
 
@@ -13,15 +12,18 @@ from Simulation_engine.simulate_pop_from_reform import (
 
 
 def generate_default_results():
-    # Keeping computations short with option to keep file under 1000 FF
-    # DUMMY_DATA = DUMMY_DATA[(DUMMY_DATA["idmen"] > 2500) & (DUMMY_DATA["idmen"] < 7500)]
-    bulk_data_simulation, data_by_entity = simulation(PERIOD, DUMMY_DATA, TBS)
     # precalcul cas de base sur la population pour le cache
-    base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
-    base_results["avant"] = bulk_data_simulation.calculate("irpp", PERIOD)
-    simulation_plf_deciles = simulation(PERIOD, DUMMY_DATA, TBS_PLF)
-    base_results["plf"] = simulation_plf_deciles[0].calculate("irpp", PERIOD)
-    base_results[["idfoy", "avant", "plf", "wprm"]].to_csv(
+    base_results = None
+    liste_base_reformes = []
+    for reforme in TBS_DEFAULT:
+        liste_base_reformes += [reforme]
+        bulk_data_simulation, data_by_entity = simulation(
+            PERIOD, DUMMY_DATA, TBS_DEFAULT[reforme]
+        )
+        if base_results is None:
+            base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
+        base_results[reforme] = bulk_data_simulation.calculate("irpp", PERIOD)
+    base_results[["idfoy"] + liste_base_reformes + ["wprm"]].to_csv(
         "base_results.csv", index=False
     )
     return base_results

--- a/scripts/generate_default_results.py
+++ b/scripts/generate_default_results.py
@@ -23,6 +23,7 @@ def generate_default_results():
         if base_results is None:
             base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
         base_results[reforme] = bulk_data_simulation.calculate("irpp", PERIOD)
+
     base_results[["idfoy"] + liste_base_reformes + ["wprm"]].to_csv(
         "base_results.csv", index=False
     )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "gunicorn >= 19.0.0, < 20.0.0",
         "mailjet-rest >= 1.3.3, < 2.0.0",
         "openfisca-core >= 34.2.8, < 35.0.0",
-        "openfisca-france >= 48.2.0, < 49.0.0",
+        "openfisca-france >= 48.10.6, < 49.0.0",
         "pandas >= 0.24.0, < 0.25.0",
         "psycopg2 >= 2.8.3, < 3.0.0",
         "pyjwt >= 1.7.1, < 2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ setup(
     ],
     install_requires=[
         "alembic >= 1.0.11, < 2.0.0",
-        "connexion[swagger-ui] >= 2.2.0, < 3.0.0",
+        "connexion[swagger-ui] >= 2.6.0, < 3.0.0",
         "flask-cors >= 3.0.7, < 3.1.0",
-        "gunicorn >= 19.0.0, < 20.0.0",
+        "gunicorn >= 20.0.0, < 21.0.0",
         "mailjet-rest >= 1.3.3, < 2.0.0",
         "openfisca-core >= 34.2.8, < 35.0.0",
         "openfisca-france >= 48.10.6, < 49.0.0",

--- a/tests/Simulation_engine/test_simulate_pop_from_reform.py
+++ b/tests/Simulation_engine/test_simulate_pop_from_reform.py
@@ -244,13 +244,13 @@ def reform():
 
 
 @fixture
-def expected_keys_resultat():
+def requested_simulations():
     # list of keys that are supposed to appear in the results. should be ["avant",  "plf", "apres"]
     # or ["avant", "apres"]
     return sorted(list(TBS_DEFAULT.keys())) + ["apres"]
 
 
-def test_sim_pop_dict_content(reform, expected_keys_resultat):
+def test_sim_pop_dict_content(reform, requested_simulations):
     simulation_reform = simulation(PERIOD, DUMMY_DATA, reform)
     comp_result = compare(PERIOD, {"apres": simulation_reform})
     assert "total" in comp_result
@@ -259,15 +259,15 @@ def test_sim_pop_dict_content(reform, expected_keys_resultat):
     assert len(comp_result["frontieres_deciles"]) == len(comp_result["deciles"])
     assert "foyers_fiscaux_touches" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
-    for key in expected_keys_resultat:
+    for key in requested_simulations:
         assert key in comp_result["total"]
         assert key in comp_result["deciles"][0]
-    for index_key_1 in range(len(expected_keys_resultat)):
-        for index_key_2 in range(index_key_1 + 1, len(expected_keys_resultat)):
+    for index_key_1 in range(len(requested_simulations)):
+        for index_key_2 in range(index_key_1 + 1, len(requested_simulations)):
             key = (
-                expected_keys_resultat[index_key_1]
+                requested_simulations[index_key_1]
                 + "_to_"
-                + expected_keys_resultat[index_key_2]
+                + requested_simulations[index_key_2]
             )
             # list of keys checked can be for example ["avant_to_apres", "avant_to_plf", "plf_to_apres"]
             assert key in comp_result["foyers_fiscaux_touches"]
@@ -284,7 +284,7 @@ def test_sim_pop_dict_content(reform, expected_keys_resultat):
                 assert isinstance(nb_people, int)
 
 
-def test_sim_base_cas_types_dict_content_ok(reform, expected_keys_resultat):
+def test_sim_base_cas_types_dict_content_ok(reform, requested_simulations):
     simulation_reform = simulation(PERIOD, CAS_TYPE, reform)
     simulations_cas_types = simulations_reformes_par_defaut_castypes
     simulations_cas_types["apres"] = simulation_reform
@@ -292,13 +292,13 @@ def test_sim_base_cas_types_dict_content_ok(reform, expected_keys_resultat):
     assert "total" in comp_result
     assert "res_brut" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
-    for key in expected_keys_resultat:
+    for key in requested_simulations:
         assert key in comp_result["total"]
         assert key in comp_result["res_brut"]
         assert len(comp_result["res_brut"][key]) == 6
 
 
-def test_sim_custom_cas_types_dict_content_ok(expected_keys_resultat):
+def test_sim_custom_cas_types_dict_content_ok(requested_simulations):
     dict_cas = [
         {
             "nombre_declarants": 1,
@@ -333,7 +333,7 @@ def test_sim_custom_cas_types_dict_content_ok(expected_keys_resultat):
     assert "total" in comp_result
     assert "res_brut" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
-    for key in expected_keys_resultat:
+    for key in requested_simulations:
         assert key in comp_result["total"]
         assert key in comp_result["res_brut"]
         assert len(comp_result["res_brut"][key]) == len(dict_cas)

--- a/tests/Simulation_engine/test_simulate_pop_from_reform.py
+++ b/tests/Simulation_engine/test_simulate_pop_from_reform.py
@@ -18,11 +18,11 @@ from Simulation_engine.simulate_pop_from_reform import (  # type: ignore
     IncomeTaxReform,
     PERIOD,
     simulation,
-    simulation_base_castypes,
+    simulations_reformes_par_defaut_castypes,
     CompareOldNew,
     simulation_from_cas_types,
-    simulation_plf_castypes,
     TBS,
+    TBS_DEFAULT,
 )
 
 
@@ -228,14 +228,12 @@ def dict_cas_type_unipersonne_from_revenu(revenu_imposable):
 
 
 def test_inversion_variable():
-    revenus_a_tester = [10000, 20000, 100000]
+    revenus_a_tester = [10000, 20000, 100000, 500000]
     for revenu in revenus_a_tester:
-        _df_description, (
-            sim_base,
-            _data_frames_base,
-        ), _useless_sim = simulation_from_cas_types(
+        _df_description, simulations = simulation_from_cas_types(
             [dict_cas_type_unipersonne_from_revenu(revenu)]
         )
+        sim_base, _data_frames_base = simulations["avant"]
         revenu_post_calcul = sim_base.calculate_add("salaire_imposable", PERIOD)[0]
         assert round(revenu_post_calcul) == round(revenu)
 
@@ -245,7 +243,14 @@ def reform():
     return IncomeTaxReform(TBS, dictreform, PERIOD)
 
 
-def test_sim_pop_dict_content(reform):
+@fixture
+def expected_keys_resultat():
+    # list of keys that are supposed to appear in the results. should be ["avant",  "plf", "apres"]
+    # or ["avant", "apres"]
+    return sorted(list(TBS_DEFAULT.keys())) + ["apres"]
+
+
+def test_sim_pop_dict_content(reform, expected_keys_resultat):
     simulation_reform = simulation(PERIOD, DUMMY_DATA, reform)
     comp_result = compare(PERIOD, {"apres": simulation_reform})
     assert "total" in comp_result
@@ -254,45 +259,46 @@ def test_sim_pop_dict_content(reform):
     assert len(comp_result["frontieres_deciles"]) == len(comp_result["deciles"])
     assert "foyers_fiscaux_touches" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
-    for key in ["avant", "apres", "plf"]:
+    for key in expected_keys_resultat:
         assert key in comp_result["total"]
         assert key in comp_result["deciles"][0]
-    for key in ["avant_to_apres", "avant_to_plf", "plf_to_apres"]:
-        assert key in comp_result["foyers_fiscaux_touches"]
-        for type_touche, nb_people in comp_result["foyers_fiscaux_touches"][
-            key
-        ].items():
-            assert type_touche in [
-                "gagnant",
-                "neutre",
-                "perdant",
-                "perdant_zero",
-                "neutre_zero",
-            ]
-            assert isinstance(nb_people, int)
+    for index_key_1 in range(len(expected_keys_resultat)):
+        for index_key_2 in range(index_key_1 + 1, len(expected_keys_resultat)):
+            key = (
+                expected_keys_resultat[index_key_1]
+                + "_to_"
+                + expected_keys_resultat[index_key_2]
+            )
+            # list of keys checked can be for example ["avant_to_apres", "avant_to_plf", "plf_to_apres"]
+            assert key in comp_result["foyers_fiscaux_touches"]
+            for type_touche, nb_people in comp_result["foyers_fiscaux_touches"][
+                key
+            ].items():
+                assert type_touche in [
+                    "gagnant",
+                    "neutre",
+                    "perdant",
+                    "perdant_zero",
+                    "neutre_zero",
+                ]
+                assert isinstance(nb_people, int)
 
 
-def test_sim_base_cas_types_dict_content_ok(reform):
+def test_sim_base_cas_types_dict_content_ok(reform, expected_keys_resultat):
     simulation_reform = simulation(PERIOD, CAS_TYPE, reform)
-    comp_result = compare(
-        PERIOD,
-        {
-            "avant": simulation_base_castypes,
-            "plf": simulation_plf_castypes,
-            "apres": simulation_reform,
-        },
-        compute_deciles=False,
-    )
+    simulations_cas_types = simulations_reformes_par_defaut_castypes
+    simulations_cas_types["apres"] = simulation_reform
+    comp_result = compare(PERIOD, simulations_cas_types, compute_deciles=False)
     assert "total" in comp_result
     assert "res_brut" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
-    for key in ["avant", "apres", "plf"]:
+    for key in expected_keys_resultat:
         assert key in comp_result["total"]
         assert key in comp_result["res_brut"]
         assert len(comp_result["res_brut"][key]) == 6
 
 
-def test_sim_custom_cas_types_dict_content_ok():
+def test_sim_custom_cas_types_dict_content_ok(expected_keys_resultat):
     dict_cas = [
         {
             "nombre_declarants": 1,
@@ -327,7 +333,7 @@ def test_sim_custom_cas_types_dict_content_ok():
     assert "total" in comp_result
     assert "res_brut" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
-    for key in ["avant", "apres", "plf"]:
+    for key in expected_keys_resultat:
         assert key in comp_result["total"]
         assert key in comp_result["res_brut"]
         assert len(comp_result["res_brut"][key]) == len(dict_cas)

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -49,6 +49,8 @@ def payload() -> dict:
 
 
 def test_calculate_compare_with_cas_types(client, payload, headers):
+    # Vérifie qu'une simulation qui ne contient pas les cas types renvoie les mêmes résultats
+    # qu'une simulation avec les cas-types par défaut
     cas_types = json.loads(client.post("metadata/description_cas_types").data)
     response = partial(client.post, "calculate/compare", headers=headers)
     payload_full = dict({**payload, "description_cas_types": cas_types})
@@ -57,9 +59,6 @@ def test_calculate_compare_with_cas_types(client, payload, headers):
     expected = json.loads(response(data=json.dumps(payload_full)).data)
 
     assert actual.keys() == expected.keys()
-    for var_in_res_brut in ["avant", "apres", "plf"]:
-        assert var_in_res_brut in expected["res_brut"]
-        assert var_in_res_brut in expected["total"]
 
     assert actual["res_brut"] == expected["res_brut"]
     assert actual["total"] == expected["total"]
@@ -67,10 +66,11 @@ def test_calculate_compare_with_cas_types(client, payload, headers):
 
 
 def test_calculate_compare_weights(client, payload, headers):
+    # Vérifie que les cas types des résultats apparaissent tous dans tous les champs
     response = partial(client.post, "calculate/compare", headers=headers)
     actual = json.loads(response(data=json.dumps(payload)).data)
 
-    for var_in_res_brut in ["avant", "apres", "plf"]:
+    for var_in_res_brut in actual["res_brut"].keys():
         assert set(actual["res_brut"]["wprm"].keys()) == set(
             actual["res_brut"][var_in_res_brut].keys()
         )


### PR DESCRIPTION
Connected to betagouv/leximpact-server#70

+ Retire le PLF par défaut, tout en donnant la possibilité de le remettre
+ Le programme est plus smart et regarde si on a des données sur la population pour décider de la brancher ou pas (cf issue #70 de betagouv/leximpact-server
+ quelques modifications de structure pour pouvoir le rebrancher facilement.