### PR TITLE
Nbptr in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,11 @@ Où `PAC` désigne `personne à charge`.
   - res_brut : Impôts payés par les cas-types : 
     - res_brut.avant : Impôt payé avec le code existant 
     - res_brut.plf : Impôt payé avec le PLF 
-    - res_brut.apres : Impot payé avec la réforme sépcifiée par la requête.
+    - res_brut.apres : Impot payé avec la réforme spécifiée par la requête.
+  - nbreParts : Nombre de parts fiscales des cas-types : 
+    - nbreParts.avant : Nombre de parts avec le code existant 
+    - nbreParts.plf : Nombre de parts avec le PLF 
+    - nbreParts.apres : Nombre de parts avec la réforme spécifiée par la requête.
   - timestamp : Chaîne de caractères reçue dans la requête 
   - total : somme des impôts payés par les cas-types dans les trois scénarios. Inutile pour cette requête. 
 
@@ -377,15 +381,33 @@ Où `PAC` désigne `personne à charge`.
              "3":0,
              "4":-1655,
              "5":-772
-          },
-          "wprm":{
-             "0":1,
-             "1":1,
-             "2":1,
-             "3":1,
-             "4":1,
-             "5":1
           }
+       },       
+        "nbreParts":{
+          "apres": {
+            "0": 1.0,
+            "1": 1.5,
+            "2": 2.0,
+            "3": 2.0,
+            "4": 3.0,
+            "5": 3.0
+            },
+          "avant": {
+            "0": 1.0,
+            "1": 1.5,
+            "2": 2.0,
+            "3": 2.0,
+            "4": 3.0,
+            "5": 3.0
+            },
+          "plf": {
+            "0": 1.0,
+            "1": 1.5,
+            "2": 2.0,
+            "3": 2.0,
+            "4": 3.0,
+            "5": 3.0
+            }
        },
        "timestamp":"1234564689",
        "total":{

--- a/README.md
+++ b/README.md
@@ -348,7 +348,8 @@ Où `PAC` désigne `personne à charge`.
     - res_brut.avant : Impôt payé avec le code existant 
     - res_brut.plf : Impôt payé avec le PLF 
     - res_brut.apres : Impot payé avec la réforme spécifiée par la requête.
-  - nbreParts : Nombre de parts fiscales des cas-types : 
+  - nbreParts : Nombre de parts fiscales des cas-types :
+    > Le champ `nbreParts` est ajouté à la réponse en version `1.2.0`.
     - nbreParts.avant : Nombre de parts avec le code existant 
     - nbreParts.plf : Nombre de parts avec le PLF 
     - nbreParts.apres : Nombre de parts avec la réforme spécifiée par la requête.

--- a/Simulation_engine/reform_nbptr.py
+++ b/Simulation_engine/reform_nbptr.py
@@ -195,15 +195,9 @@ def generate_nbptr_class(
             # # note 3 : Pas de personne à charge
             # - invalide
 
-            n31a = quotient_familial.not31a * (no_pac & no_alt & caseP)
-            # - ancien combatant
-            n31b = quotient_familial.not31b * (no_pac & no_alt & (caseW | caseG))
-            n31 = max_(n31a, n31b)
-            # - personne seule ayant élevé des enfants
-            n32 = quotient_familial.not32 * (
-                no_pac & no_alt & ((caseE | caseK | caseL) & not_(caseN))
-            )
-            n3 = max_(n31, n32)
+            # La formulation de l'article 195 nous pousse à faire ceci pour plus de cohérence.
+            # Ce sont les cas couverts par l'alinéa 1 de l'article 195 du CGI
+            n3 = (1.5 - enf) * (no_pac & no_alt & (caseW | caseG | caseP | ((caseE | caseK | caseL) & not_(caseN))))
             # # note 4 Invalidité de la personne ou du conjoint pour les mariés ou
             # # jeunes veuf(ve)s
             n4 = max_(

--- a/Simulation_engine/reform_nbptr.py
+++ b/Simulation_engine/reform_nbptr.py
@@ -199,7 +199,10 @@ def generate_nbptr_class(
 
             # La formulation de l'article 195 nous pousse à faire ceci pour plus de cohérence.
             # Ce sont les cas couverts par l'alinéa 1 de l'article 195 du CGI
-            n3 = (1.5 - enf) * (no_pac & no_alt & (caseW | caseG | caseP | ((caseE | caseK | caseL) & not_(caseN))))
+            conditions_invalidite = caseP
+            conditions_combattant = caseW | caseG
+            conditions_seul_enfants = (caseE | caseK | caseL) & not_(caseN)  # demie-part supplémentaire
+            n3 = (1.5 - enf) * (no_pac & no_alt & (conditions_combattant | conditions_invalidite | conditions_seul_enfants))
             # # note 4 Invalidité de la personne ou du conjoint pour les mariés ou
             # # jeunes veuf(ve)s
             n4 = max_(

--- a/Simulation_engine/reform_nbptr.py
+++ b/Simulation_engine/reform_nbptr.py
@@ -234,7 +234,7 @@ def generate_nbptr_class(
             nb_parts_famille = enf + n2 + n4
 
             # # veufs  hors jeune_veuf
-            nb_parts_veuf = enf + n2 + n3 + n6
+            nb_parts_veuf = enf + n2 + n3 + n6 + n7
 
             # # celib div
             nb_parts_celib = enf + n2 + n3 + n6 + n7

--- a/Simulation_engine/reform_nbptr.py
+++ b/Simulation_engine/reform_nbptr.py
@@ -88,9 +88,11 @@ def generate_nbptr_class(
     class nbptr(Variable):
         value_type = float
         entity = FoyerFiscal
-        label = "Nombre de parts"
-        reference = "http://vosdroits.service-public.fr/particuliers/F2705.xhtml"
         definition_period = YEAR
+        label = "Nombre de parts"
+        reference = [
+            "http://vosdroits.service-public.fr/particuliers/F2705.xhtml",
+            "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006308287"]
 
         def formula(foyer_fiscal, period, parameters):
             """

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -216,9 +216,10 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
             impots_par_reforme["rfr"] = dictionnaire_simulations[nom_simulation][
                 0
             ].calculate("rfr", period)
-        nbptr_par_reforme[nom_simulation] = dictionnaire_simulations[nom_simulation][
-            0
-        ].calculate("nbptr", period)
+        else:  # Evitons de calculer le nbptr quand on fait toute la population
+            nbptr_par_reforme[nom_simulation] = dictionnaire_simulations[nom_simulation][
+                0
+            ].calculate("nbptr", period)
 
     for nom_res_base in liste_noms_reformes_avec_apres:
         res[nom_res_base] = -(

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -294,15 +294,10 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         dic_res_brut = impots_par_reforme.to_dict()
         del dic_res_brut["wprm"]
         for simu in dic_res_brut:
-            if simu != "wprm":
-                for cas_type in dic_res_brut[simu]:
-                    dic_res_brut[simu][cas_type] = int(round(dic_res_brut[simu][cas_type]))
+            for cas_type in dic_res_brut[simu]:
+                dic_res_brut[simu][cas_type] = int(round(dic_res_brut[simu][cas_type]))
         dic_nbptr = nbptr_par_reforme.to_dict()
         del dic_nbptr["wprm"]
-        for simu in dic_nbptr:
-            if simu != "wprm":
-                for cas_type in dic_nbptr[simu]:
-                    dic_nbptr[simu][cas_type] = dic_nbptr[simu][cas_type]
         resultat = {"total": total, "res_brut": dic_res_brut, "nbreParts": dic_nbptr}
 
     return resultat

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -291,13 +291,17 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
     else:  # This only interests us for the castypes
         # On arrondit les résultats des cas-types
         dic_res_brut = impots_par_reforme.to_dict()
+        del dic_res_brut["wprm"]
         for simu in dic_res_brut:
-            for cas_type in dic_res_brut[simu]:
-                dic_res_brut[simu][cas_type] = int(round(dic_res_brut[simu][cas_type]))
+            if simu != "wprm":
+                for cas_type in dic_res_brut[simu]:
+                    dic_res_brut[simu][cas_type] = int(round(dic_res_brut[simu][cas_type]))
         dic_nbptr = nbptr_par_reforme.to_dict()
+        del dic_nbptr["wprm"]
         for simu in dic_nbptr:
-            for cas_type in dic_nbptr[simu]:
-                dic_nbptr[simu][cas_type] = dic_nbptr[simu][cas_type]
+            if simu != "wprm":
+                for cas_type in dic_nbptr[simu]:
+                    dic_nbptr[simu][cas_type] = dic_nbptr[simu][cas_type]
         resultat = {"total": total, "res_brut": dic_res_brut, "nbreParts": dic_nbptr}
 
     return resultat

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -205,6 +205,9 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         impots_par_reforme = next(iter(dictionnaire_simulations.values()))[1][
             "foyer_fiscal"
         ][["wprm"]]
+    nbptr_par_reforme = next(iter(dictionnaire_simulations.values()))[1][
+        "foyer_fiscal"
+    ][["wprm"]]
     for nom_simulation in dictionnaire_simulations:
         impots_par_reforme[nom_simulation] = dictionnaire_simulations[nom_simulation][
             0
@@ -213,6 +216,9 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
             impots_par_reforme["rfr"] = dictionnaire_simulations[nom_simulation][
                 0
             ].calculate("rfr", period)
+        nbptr_par_reforme[nom_simulation] = dictionnaire_simulations[nom_simulation][
+            0
+        ].calculate("nbptr", period)
 
     for nom_res_base in liste_noms_reformes_avec_apres:
         res[nom_res_base] = -(
@@ -287,7 +293,11 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         for simu in dic_res_brut:
             for cas_type in dic_res_brut[simu]:
                 dic_res_brut[simu][cas_type] = int(round(dic_res_brut[simu][cas_type]))
-        resultat = {"total": total, "res_brut": dic_res_brut}
+        dic_nbptr = nbptr_par_reforme.to_dict()
+        for simu in dic_nbptr:
+            for cas_type in dic_nbptr[simu]:
+                dic_nbptr[simu][cas_type] = dic_nbptr[simu][cas_type]
+        resultat = {"total": total, "res_brut": dic_res_brut, "nbreParts": dic_nbptr}
 
     return resultat
 

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -194,6 +194,11 @@ def calcule_personnes_touchees(impots_par_reforme):
     return foyers_fiscaux_touches
 
 
+def dataframe_pondere(dictionnaire_simulations: Dict) -> pandas.DataFrame:
+    # Pondération des foyers fiscaux : une ligne par foyer fiscal, une colonne pour le poids (wprm)
+    return next(iter(dictionnaire_simulations.values()))[1]["foyer_fiscal"][["wprm"]]
+
+
 def compare(period: str, dictionnaire_simulations, compute_deciles=True):
     res: Total = {}
     if (
@@ -202,12 +207,8 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         # Donc il doit déjà être dans resulats_de_base
         impots_par_reforme = resultats_de_base.copy()
     else:
-        impots_par_reforme = next(iter(dictionnaire_simulations.values()))[1][
-            "foyer_fiscal"
-        ][["wprm"]]
-    nbptr_par_reforme = next(iter(dictionnaire_simulations.values()))[1][
-        "foyer_fiscal"
-    ][["wprm"]]
+        impots_par_reforme = dataframe_pondere(dictionnaire_simulations)
+    nbptr_par_reforme = dataframe_pondere(dictionnaire_simulations)
     for nom_simulation in dictionnaire_simulations:
         impots_par_reforme[nom_simulation] = dictionnaire_simulations[nom_simulation][
             0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="LexImpact Server",
     author="LexImpact Team",
     author_email="leximpact@openfisca.org",
-    version="1.1.0",
+    version="1.2.0",
     license="https://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/betagouv/leximpact",
     classifiers=[

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -72,12 +72,12 @@ def test_calculate_compare_presence_cas_types(client, payload, headers):
     # Vérifie que les cas types des résultats apparaissent tous dans tous les champs
     response = partial(client.post, "calculate/compare", headers=headers)
     actual = json.loads(response(data=json.dumps(payload)).data)
-    master_to_compare = None
-    for var_in_res_brut in actual["res_brut"].keys():
-        if master_to_compare is None:
-            master_to_compare = set(actual["res_brut"][var_in_res_brut].keys())
-        assert master_to_compare == set(
-            actual["res_brut"][var_in_res_brut].keys()
+    first_simulation_cas_type_ids = None
+    for simulation_name in actual["res_brut"].keys():
+        if first_simulation_cas_type_ids is None:
+            first_simulation_cas_type_ids = set(actual["res_brut"][simulation_name].keys())
+        assert first_simulation_cas_type_ids == set(
+            actual["res_brut"][simulation_name].keys()
         )
 
 

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -236,3 +236,14 @@ def test_calculate_compare_response(client, headers, payload):
 
     nbreParts_apres = dpath.get(response_json, 'nbreParts/apres')
     assert list(nbreParts_apres.keys()) == ['0', '1', '2', '3', '4', '5']  # 6 cas types par défaut
+
+
+def test_calculate_compare_response_on_nbptr(client, headers, payload):
+    request_data = json.dumps(payload)
+    response = client.post("calculate/compare", data=request_data, headers=headers)
+
+    assert response.status_code == CREATED  # 201
+
+    response_json = json.loads(response.data.decode('utf-8'))
+    nombre_parts_cas_types_2020 = { "0": 1.0, "1": 1.5, "2": 2.0, "3": 2.0, "4": 3.0, "5": 3.0 }
+    assert dpath.get(response_json, 'nbreParts/avant') == nombre_parts_cas_types_2020

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -1,7 +1,10 @@
-from functools import partial
-import json
-from datetime import datetime
 import pytest  # type: ignore
+import json
+import dpath
+
+from functools import partial
+from datetime import datetime
+from http.client import CREATED
 
 
 @pytest.fixture
@@ -210,3 +213,19 @@ def test_calculate_compare_lexception(client, headers):
     assert json.loads(response.data) == {
         "Error": "Error in request : the field 'partsSelonNombrePAC' is missing from 'calculNombreParts'. You can refer to the README to check valid format."
     }
+
+
+def test_calculate_compare_response(client, headers, payload):
+    request_data = json.dumps(payload)
+    response = client.post("calculate/compare", data=request_data, headers=headers)
+
+    assert response.status_code == CREATED  # 201
+    response_json = json.loads(response.data.decode('utf-8'))
+
+    res_brut = dpath.get(response_json, 'res_brut')
+    assert res_brut is not None
+    assert list(res_brut.keys()) == ['apres', 'avant']
+
+    nbreParts = dpath.get(response_json, 'nbreParts')
+    assert nbreParts is not None
+    assert list(nbreParts.keys()) == ['apres', 'avant']

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -1,6 +1,6 @@
 import pytest  # type: ignore
+import dpath  # type: ignore
 import json
-import dpath
 
 from functools import partial
 from datetime import datetime
@@ -216,6 +216,7 @@ def test_calculate_compare_lexception(client, headers):
 
 
 def test_calculate_compare_response(client, headers, payload):
+    # Par défaut, la réponse contient l'impôt et le nombre de parts par cas type
     request_data = json.dumps(payload)
     response = client.post("calculate/compare", data=request_data, headers=headers)
 
@@ -226,6 +227,12 @@ def test_calculate_compare_response(client, headers, payload):
     assert res_brut is not None
     assert list(res_brut.keys()) == ['apres', 'avant']
 
+    res_brut_apres = dpath.get(response_json, 'res_brut/apres')
+    assert list(res_brut_apres.keys()) == ['0', '1', '2', '3', '4', '5']  # 6 cas types par défaut
+
     nbreParts = dpath.get(response_json, 'nbreParts')
     assert nbreParts is not None
     assert list(nbreParts.keys()) == ['apres', 'avant']
+
+    nbreParts_apres = dpath.get(response_json, 'nbreParts/apres')
+    assert list(nbreParts_apres.keys()) == ['0', '1', '2', '3', '4', '5']  # 6 cas types par défaut

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -245,5 +245,5 @@ def test_calculate_compare_response_on_nbptr(client, headers, payload):
     assert response.status_code == CREATED  # 201
 
     response_json = json.loads(response.data.decode('utf-8'))
-    nombre_parts_cas_types_2020 = { "0": 1.0, "1": 1.5, "2": 2.0, "3": 2.0, "4": 3.0, "5": 3.0 }
+    nombre_parts_cas_types_2020 = {"0": 1.0, "1": 1.5, "2": 2.0, "3": 2.0, "4": 3.0, "5": 3.0}
     assert dpath.get(response_json, 'nbreParts/avant') == nombre_parts_cas_types_2020

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -65,13 +65,15 @@ def test_calculate_compare_with_cas_types(client, payload, headers):
     assert actual["timestamp"] == expected["timestamp"]
 
 
-def test_calculate_compare_weights(client, payload, headers):
+def test_calculate_compare_presence_cas_types(client, payload, headers):
     # Vérifie que les cas types des résultats apparaissent tous dans tous les champs
     response = partial(client.post, "calculate/compare", headers=headers)
     actual = json.loads(response(data=json.dumps(payload)).data)
-
+    master_to_compare = None
     for var_in_res_brut in actual["res_brut"].keys():
-        assert set(actual["res_brut"]["wprm"].keys()) == set(
+        if master_to_compare is None:
+            master_to_compare = set(actual["res_brut"][var_in_res_brut].keys())
+        assert master_to_compare == set(
             actual["res_brut"][var_in_res_brut].keys()
         )
 


### PR DESCRIPTION
- Fait désormais apparaître le nombre de parts avant et après.
  > Dans les réponses aux simulations pour cas types demandées via endpoint `/calculate/compare`
- Permet de matcher le résultat openfisca dans le cas d'un veuf qui coche les cases T sauvagement.
- Corrige la gestion de l'article 195 : comme le spécifie la loi on met à 1.5 les personnes concernées par le premier alinéa au lieu de leur rajouter 0.5 comme avant.

- retire le wprm des res_bruts
  > Dans les réponses aux simulations pour cas types demandées via endpoint `/calculate/compare`


Pour les suites :  https://trello.com/c/2ROMnHFU/300-parent-isol%C3%A9-la-revanche
