### PR TITLE
Calcule l'éligibilité DSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ END
 ```
 
 
-## Endpoints de l'API Web
+## Endpoints de l'API Web - Impôt sur le revenu
 
 L'API Web dispose des itinéraires suivants :
 
@@ -419,7 +419,29 @@ Où `PAC` désigne `personne à charge`.
   - foyers_fiscaux_touches : dictionnaire contenant les clefs `avant_to_plf`, `avant_to_apres`, `plf_to_apres`. Chaque élément du dictionnaire divise les foyers fiscaux en 5 catégories : `gagnant`, `perdant`, `neutre`, `neutre_zero`, `perdant_zero` : Ils décrivent si les foyers fiscaux payent plus ou moins d'impôts à l'arrivée qu'au départ. Les catégories finissant par `_zero` décrivent le foyers fiscaux qui étaient exonérés d'impôt au départ.
  Par exemple, `neutre_zero` désigne le nombre de personnes pour lesquelles l'impact est neutre (avant = après) et qui sont exonérées d'impôt (donc, avant = après = 0).
 
+## Endpoints de l'API Web - Dotations aux collectivités locales
 
+L'API Web traite également d'une thématique isolée de l'impôt sur le revenu : les dotations
+de l'État aux collectivités locales.
+
+### /dotations
+
+- Type : POST
+- Description :
+- Requête - contenu du body :
+  > En cours de définition. Valeur par défaut :
+  ```
+  {
+    "reforme": {  # décrit la réforme
+        "dotations": {  # configure les éléments de la réforme des dotations
+            "montants": {"dgf": montant de la DGF},
+            "communes": {}
+        }
+    }
+  }
+  ```
+- Réponse - contenu du body :
+  > En cours de définition. Valeur par défaut `{"hello": "coucou"}`
 
 ## Base de données
 

--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -1,3 +1,5 @@
+
+
 def simulate(request_body):
     simulation_result = {"hello": "coucou"}  # construire le body de la response dans le handler ?
     return simulation_result

--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -1,0 +1,3 @@
+def simulate(request_body):
+    simulation_result = {"hello": "coucou"}  # construire le body de la response dans le handler ?
+    return simulation_result

--- a/dotation/compare_with_dgcl.py
+++ b/dotation/compare_with_dgcl.py
@@ -1,0 +1,56 @@
+from simulation import simulation_from_dgcl_csv
+from load_dgcl_data import load_dgcl_file
+from openfisca_france_dotations_locales import CountryTaxBenefitSystem  # type: ignore
+from time import time
+
+#
+# Petit script auxiliaire pour comparer les résultats trouvés avec notre parser + OFDL
+# aux résultats trouvés.
+#
+# On peut en faire des tests, mais il y a un tradeoff entre correspondre plus précisément
+# aux résultats DGCL et obtenir des résultats cohérents plus tard.
+
+
+# Quelques noms de colonne utiles:
+elig_bc_dgcl = "Eligible fraction bourg-centre selon DGCL"
+elig_pq_dgcl = "Eligible fraction péréquation selon DGCL"
+elig_cible_dgcl = "Eligible fraction cible selon DGCL"
+code_comm = "Informations générales - Code INSEE de la commune"
+nom_comm = "Informations générales - Nom de la commune"
+
+
+tocompare = {"dsr_eligible_fraction_bourg_centre": elig_bc_dgcl,
+             "dsr_eligible_fraction_perequation": elig_pq_dgcl,
+             "dsr_eligible_fraction_cible": elig_cible_dgcl}
+
+
+def check_variables_bool(data):
+    res = {}
+    for k, v in tocompare.items():
+        res[k] = data.pivot_table(code_comm, index=k, columns=v, aggfunc="count", fill_value=0)
+    return res
+
+
+def print_eligible_comparison():
+    PERIOD = "2020"
+    DATA = load_dgcl_file()
+    TBS = CountryTaxBenefitSystem()
+    sim = simulation_from_dgcl_csv(PERIOD, DATA, TBS)
+    colonnes_to_compare = ["dsr_eligible_fraction_bourg_centre",
+                           "dsr_eligible_fraction_perequation",
+                           "dsr_eligible_fraction_cible"]
+
+    for variable_to_compute in colonnes_to_compare + ["indice_synthetique_dsr_cible", "rang_indice_synthetique_dsr_cible"]:
+        DATA[variable_to_compute] = sim.calculate(variable_to_compute, PERIOD)
+
+    DATA.to_csv("data_compare.csv")
+
+    for nom_ofdl, resultats_comparaison in check_variables_bool(DATA).items():
+        print("Comparaison DGCL vs nous pour le calcul de", nom_ofdl)
+        print(resultats_comparaison)
+
+
+if __name__ == "__main__":
+    st = time()
+    print_eligible_comparison()
+    print("Elapsed : {:.2f}".format(time() - st))

--- a/dotation/impact.py
+++ b/dotation/impact.py
@@ -12,7 +12,7 @@ table_transcription_leximpact_ofdl = {"communes.dsr.eligibilite.popMax": "dotati
                                       "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
                                       "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
                                       "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
-                                      "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
+                                      "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_potentiel_financier",
                                       "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu", }
 
 

--- a/dotation/impact.py
+++ b/dotation/impact.py
@@ -1,0 +1,28 @@
+from simulation import resultfromreforms
+
+
+def impacts_reforme_dotation(reforme):
+    variables_nombre_communes = ["dsr_eligible_fraction_bourg_centre", "dsr_eligible_fraction_perequation", "dsr_eligible_fraction_cible"]
+    to_compute = variables_nombre_communes
+    df_results = resultfromreforms({"apres" : reforme}, to_compute)
+    res = {}
+    for scenario in ["avant", "apres"]:
+        res[scenario] = {}
+        for col in variables_nombre_communes:
+            res[scenario]["nombre_communes_" + col] = df_results[col + "_" + scenario].sum()
+    return res
+
+
+if __name__ == "__main__":
+    reforme_example = {
+        "dgf": {
+            "dotation_solidarite_rurale": {
+                "cible": {
+                    "eligibilite": {
+                        "seuil_classement": 23
+                    }
+                }
+            }
+        }
+    }
+    print(impacts_reforme_dotation(reforme_example))

--- a/dotation/impact.py
+++ b/dotation/impact.py
@@ -1,4 +1,23 @@
 from simulation import resultfromreforms
+from utils_dict import translate_dict
+
+
+table_transcription_leximpact_ofdl = {"communes.dsr.eligibilite.popMax": "dotation_solidarite_rurale.seuil_nombre_habitants",
+                                      "communes.dsr.eligibilite.popChefLieuMax": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_nombre_habitants_chef_lieu",
+                                      "communes.dsr.bourgcentre.eligibilite.partPopCantonMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_part_population_canton",
+                                      "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.partPopDepartementMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_part_population_dgf_agglomeration_departement",
+                                      "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_agglomeration",
+                                      "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popCommuneMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_maximum_commune_agglomeration",
+                                      "communes.dsr.bourgcentre.eligibilite.exclusion.canton.popChefLieuMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_chef_lieu_de_canton",
+                                      "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
+                                      "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
+                                      "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
+                                      "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
+                                      "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu", }
+
+
+def format_reforme_openfisca(reforme_a_traduire):
+    return translate_dict(reforme_a_traduire, table_transcription_leximpact_ofdl)
 
 
 def impacts_reforme_dotation(reforme):
@@ -26,3 +45,16 @@ if __name__ == "__main__":
         }
     }
     print(impacts_reforme_dotation(reforme_example))
+
+    reforme_example_api = {
+        "communes" : {
+            "dsr" : {
+                "cible": {
+                    "eligibilie": {
+                        "premieresCommunes": 23
+                    }
+                }
+            }
+        }
+    }
+    print(impacts_reforme_dotation(format_reforme_openfisca(reforme_example_api)))

--- a/dotation/load_dgcl_data.py
+++ b/dotation/load_dgcl_data.py
@@ -1,0 +1,158 @@
+import pandas
+
+
+# Quelques noms de colonne utiles:
+elig_bc_dgcl = "Eligible fraction bourg-centre selon DGCL"
+elig_pq_dgcl = "Eligible fraction péréquation selon DGCL"
+elig_cible_dgcl = "Eligible fraction cible selon DGCL"
+code_comm = "Informations générales - Code INSEE de la commune"
+nom_comm = "Informations générales - Nom de la commune"
+
+# Variables openfisca-france-dotations-locales présentes à l'état brut dans le fichier avec le nom de colonne correspondant.
+
+variables_openfisca_presentes_fichier = {
+    'bureau_centralisateur': 'Dotation de solidarité rurale Bourg-centre - Bureaux centralisateurs',
+    'chef_lieu_arrondissement': "Dotation de solidarité rurale Bourg-centre - Chef-lieu d'arrondissement au 31 décembre 2014",
+    'chef_lieu_de_canton': 'Dotation de solidarité rurale Bourg-centre - Code commune chef-lieu de canton au 1er janvier 2014',
+    'chef_lieu_departement_dans_agglomeration': 'Dotation de solidarité rurale Bourg-centre - Chef-lieu de département agglo',
+    'part_population_canton': 'Dotation de solidarité rurale Bourg-centre - Pourcentage de la population communale dans le canton',
+    'population_dgf': "Informations générales - Population DGF Année N'",
+    'population_dgf_agglomeration': "Dotation de solidarité rurale Bourg-centre - Population DGF des communes de l'agglomération",
+    'population_dgf_departement_agglomeration': "Dotation de solidarité rurale Bourg-centre - Population départementale de référence de l'agglomération",
+    'population_dgf_plafonnee': 'Dotation de solidarité rurale Bourg-centre - Population DGF plafonnée',
+    'population_insee': 'Informations générales - Population INSEE Année N ',
+    'potentiel_financier': 'Potentiel fiscal et financier des communes - Potentiel financier',
+    'potentiel_financier_par_habitant': 'Potentiel fiscal et financier des communes - Potentiel financier par habitant',
+    'revenu_total': 'Dotation de solidarité urbaine - Revenu imposable des habitants de la commune',
+    'strate_demographique': 'Informations générales - Strate démographique Année N'
+}
+
+# A partir de l'adresse du tableau publié par la DGCL, produit un tableau contenant toutes les colonnes nécessaires
+# au calcul des dotations.
+# il a deux sources de données :
+# - des colonnes déjà présentes dans le fichier (qu'il suffit de renommer), leur nom
+# est présent dans le dictionnaire variables_openfisca_presentes_fichier. On
+# met aussi tout ce qui apparait dans autres_cols_interessantes (pour qu'un export)
+# de data soit sympa;
+# - des colonnes qu'il faut construire, et qui sont ajoutées petit à petit
+# La fonction outputte un dataframe qui contient des variables openfisca
+# et d'autres colonnes sympas. On fait la différence super facilement car toutes
+# les colonnes non-openfisca contiennent un espace. Je sais, c'est propre.
+
+
+# Fichiers disponibles sur https://www.data.gouv.fr/fr/datasets/dotations-globales-de-fonctionnement/
+def load_dgcl_file(path="2019-communes-criteres-repartition.csv"):
+    data = pandas.read_csv(path, decimal=",")
+    extracolumns = {}
+    #
+    # add_plus_grande_commune_agglo_column
+    #
+    # Niveau ceinture blanche : on groupe by la taille totale de l'agglo (c'est ce qu'on fait icis)
+    # Niveau ceinture orange : en plus de ce critère, utiliser des critères géographiques pour localiser les agglos.
+    # Ceinture rouge : on trouve des données sur les agglos de référence de chaque commune
+    pop_agglo = variables_openfisca_presentes_fichier["population_dgf_agglomeration"]
+    pop_dgf = variables_openfisca_presentes_fichier["population_dgf"]
+    max_pop_plus_grosse_commune = data.groupby(pop_agglo)[[pop_dgf]].max()
+    # Ca marche car le plus haut nombre d'habitants à être partagé par 2 agglo est 23222
+    # print(somme_pop_plus_grosse_commune[somme_pop_plus_grosse_commune.index!=somme_pop_plus_grosse_commune[somme_pop_plus_grosse_commune.columns[0]]])
+    plus_grosse_commune = "Population plus grande commune de l'agglomération"
+    max_pop_plus_grosse_commune.columns = [plus_grosse_commune]
+    max_pop_plus_grosse_commune.loc[max_pop_plus_grosse_commune.index == 0, plus_grosse_commune] = 0
+    data = data.merge(max_pop_plus_grosse_commune, left_on=pop_agglo, right_index=True).sort_index()
+    extracolumns["population_dgf_maximum_commune_agglomeration"] = plus_grosse_commune
+
+    #
+    # deux communes ont une part ui apparait >= à 15% du canton mais en fait non. On triche mais pas beaucoup, la part dans la population du canton
+    # n'est pas une info facile à choper exactement.
+    #
+    part_population_canton = variables_openfisca_presentes_fichier["part_population_canton"]
+    data.loc[(data[code_comm] == 57163) | (data[code_comm] == 87116), part_population_canton] -= 0.0001
+    print(data[(data[code_comm] == 57163) | (data[code_comm] == 87116)][[nom_comm, part_population_canton]])
+    #
+    # introduit la valeur d'outre mer
+    #
+    departement = "Informations générales - Code département de la commune"
+    data[departement] = data[departement].astype(str)
+    outre_mer_dgcl = "commune d'outre mer"
+    data[outre_mer_dgcl] = (data[departement].str.len() > 2) & (~data[departement].str.contains("A")) & (~data[departement].str.contains("B"))
+    extracolumns["outre_mer"] = outre_mer_dgcl
+
+    #
+    # Chope les infos du chef-lieu de canton
+    #
+    is_chef_lieu_canton = "Chef-lieu de canton"
+    chef_lieu_de_canton_dgcl = "Dotation de solidarité rurale Bourg-centre - Code commune chef-lieu de canton au 1er janvier 2014"
+    data[is_chef_lieu_canton] = (data[chef_lieu_de_canton_dgcl] == data[code_comm])
+    extracolumns["chef_lieu_de_canton"] = is_chef_lieu_canton
+
+    table_chef_lieu_canton = data[[code_comm, pop_dgf]]
+    pop_dgf_chef_lieu_canton = pop_dgf + " du chef-lieu de canton"
+    table_chef_lieu_canton.columns = [code_comm, pop_dgf_chef_lieu_canton]
+    data = data.merge(table_chef_lieu_canton, left_on=chef_lieu_de_canton_dgcl, right_on=code_comm, how="left", suffixes=("", "_Chef_lieu"))
+    data[pop_dgf_chef_lieu_canton] = data[pop_dgf_chef_lieu_canton].fillna(0).astype(int)
+    extracolumns["population_dgf_chef_lieu_de_canton"] = pop_dgf_chef_lieu_canton
+
+    # Corrige les infos sur le revenu total de la commune quand il est à 0 et que l'indice synthétique est renseigné
+    # Certains revenus moyens sont missing...
+    # On essaye de les remplir grâce à notre super equation:
+    # RT = pop_insee * (0.3*RMStrate)/(IS-0.7 * PF(strate)/PF)
+    # pour ceci, calculons le revenu moyen de chaque strate
+    strate = variables_openfisca_presentes_fichier["strate_demographique"]
+    revenu_total_dgcl = variables_openfisca_presentes_fichier["revenu_total"]
+    pop_insee = variables_openfisca_presentes_fichier["population_insee"]
+    tableau_donnees_par_strate = data[(~data[outre_mer_dgcl])].groupby(strate)[[pop_insee, revenu_total_dgcl]].sum()
+    revenu_moyen_strate = " Revenu imposable moyen par habitant de la strate"
+    tableau_donnees_par_strate[revenu_moyen_strate] = tableau_donnees_par_strate[revenu_total_dgcl] / tableau_donnees_par_strate[pop_insee]
+    data = data.merge(tableau_donnees_par_strate[[revenu_moyen_strate]], left_on=strate, right_index=True)
+
+    # Avant de corriger les revenus, il nous faut calculer les revenus moyens par strate
+    # Certains revenus sont ignorés dans le calcul du revenu moyen de la strate, on sait pas pourquoi
+    # (ptet la DGCL préserve le secret statistique dans ses metrics agrégées?)
+    # La conséquence de la ligne de code qui suit est qu'on utilise la même méthodo que la DGCL
+    # donc on a un classement cible plus proche de la vérité.
+    # L'inconvénient est que les revenus moyens par strate ne sont pas reproductibles en l'état
+    # On pourrait rajouter une variable dans Openfisca qui dirait "est ce que cette commune est
+    # prise en compte dans la moyenne de revenu moyen par strate?" , mais le calcul de cette variable
+    # n'est pas dans la loi.
+    extracolumns["revenu_par_habitant_moyen"] = revenu_moyen_strate
+
+    actual_indice_synthetique = "Dotation de solidarité rurale - Cible - Indice synthétique"
+    revenu_moyen_strate = " Revenu imposable moyen par habitant de la strate"
+    pot_fin_strate = "Potentiel fiscal et financier des communes - Potentiel financier moyen de la strate"
+    pot_fin_par_hab = "Potentiel fiscal et financier des communes - Potentiel financier par habitant"
+    data.loc[(data[revenu_total_dgcl] == 0) & (data[pop_insee] > 0) & (data[actual_indice_synthetique] > 0), revenu_total_dgcl] = (
+        0.3 * data[revenu_moyen_strate] / (data[actual_indice_synthetique] - 0.7 * data[pot_fin_strate] / data[pot_fin_par_hab])
+    ) * data[pop_insee]
+
+    #
+    # Génère le dataframe au format final :
+    # Il contient toutes les variables qu'on rentrera dans openfisca au format openfisca
+    # + Des variables utiles qu'on ne rentre pas dans openfisca
+    #
+    # Restriction aux colonnes intéressantes :
+    rang_indice_synthetique = "Dotation de solidarité rurale - Cible - Rang DSR Cible"
+    translation_cols = {**variables_openfisca_presentes_fichier, **extracolumns}
+    data[elig_bc_dgcl] = (data["Dotation de solidarité rurale Bourg-centre - Montant de la commune éligible"] > 0)
+    data[elig_pq_dgcl] = (data["Dotation de solidarité rurale - Péréquation - Part Pfi (avant garantie CN)"] > 0)
+    data[elig_cible_dgcl] = (data[rang_indice_synthetique] > 0) & (data[rang_indice_synthetique] <= 10000)
+
+    # Au delà des colonnes traduites, on garde ces colonnes dans le dataframe de sortie.
+    # Pour comparer nos résultats aux résultats calculés, et pour garder des informations
+    # pour identifier la commune
+    autres_cols_interessantes = [code_comm, nom_comm, rang_indice_synthetique, actual_indice_synthetique, elig_bc_dgcl, elig_pq_dgcl, elig_cible_dgcl]
+    data = data[autres_cols_interessantes + list(translation_cols.values())]
+
+    # Renomme colonnes
+    invert_dict = {name_dgcl: name_ofdl for name_ofdl, name_dgcl in translation_cols.items()}
+    data.columns = [column if column not in invert_dict else invert_dict[column] for column in data.columns]
+
+    # Passe les "booléens dgf" (oui/non) en booléens normaux
+    liste_columns_to_real_bool = ["bureau_centralisateur", "chef_lieu_arrondissement", "chef_lieu_departement_dans_agglomeration"]
+    for col in liste_columns_to_real_bool:
+        data[col] = (data[col].str.contains(pat="oui", case=False))
+
+    return data.sort_index()
+
+
+if __name__ == "__main__":
+    print(load_dgcl_file())

--- a/dotation/load_dgcl_data.py
+++ b/dotation/load_dgcl_data.py
@@ -1,4 +1,4 @@
-import pandas
+import pandas  # type: ignore
 
 
 # Quelques noms de colonne utiles:

--- a/dotation/load_dgcl_data.py
+++ b/dotation/load_dgcl_data.py
@@ -67,7 +67,6 @@ def load_dgcl_file(path="2019-communes-criteres-repartition.csv"):
     #
     part_population_canton = variables_openfisca_presentes_fichier["part_population_canton"]
     data.loc[(data[code_comm] == 57163) | (data[code_comm] == 87116), part_population_canton] -= 0.0001
-    print(data[(data[code_comm] == 57163) | (data[code_comm] == 87116)][[nom_comm, part_population_canton]])
     #
     # introduit la valeur d'outre mer
     #

--- a/dotation/reform.py
+++ b/dotation/reform.py
@@ -3,24 +3,7 @@ from openfisca_core.reforms import Reform  # type: ignore
 from openfisca_core.parameters import ParameterNode  # type: ignore
 from functools import reduce
 
-
-# Retourne un dictionnaire flattened à partir d'un nested dictionnaire
-def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
-    res = {}
-    pc = [prechain] if len(prechain) else []
-    for k, v in dict_to_traverse.items():
-        if isinstance(v, dict):
-            res = {**res, **flattened_dict(v, prechain=delimiter.join(pc + [k]))}
-        else:
-            res[delimiter.join(pc + [k])] = v
-    return res
-
-
-def test_flattened_dict():
-    a = {"a": {"b": {"c": 3, "d": {"e": 4, "f": "chaton"}}}}
-    b = {"a.b.c": 3, "a.b.d.e": 4, "a.b.d.f": "chaton"}
-    assert(flattened_dict(a) == b)
-
+from utils_dict import flattened_dict
 
 class DotationReform(Reform):
 

--- a/dotation/reform.py
+++ b/dotation/reform.py
@@ -1,0 +1,47 @@
+from openfisca_core import periods
+from openfisca_core.reforms import Reform  # type: ignore
+from openfisca_core.parameters import ParameterNode  # type: ignore
+from functools import reduce
+
+# Retourne un dictionnaire flattened à partir d'un nested dictionnaire
+def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
+    res = {}
+    pc = [prechain] if len(prechain) else []
+    for k, v in dict_to_traverse.items():
+        if isinstance(v, dict):
+            res = {**res, **flattened_dict(v, prechain=delimiter.join(pc + [k]))}
+        else:
+            res[delimiter.join(pc + [k])] = v
+    return res
+
+
+def test_flattened_dict():
+    a = {"a": {"b": {"c": 3, "d": {"e": 4, "f": "chaton"}}}}
+    b = {"a.b.c": 3, "a.b.d.e": 4, "a.b.d.f": "chaton"}
+    assert(flattened_dict(a) == b)
+
+
+class DotationReform(Reform):
+
+    def __init__(self, tbs, payload: dict) -> None:
+        self.payload = payload.get("dgf", {})
+        self.period = periods.period("year:1900:200")
+        super().__init__(tbs)
+
+    def modifier(self, parameters: ParameterNode) -> ParameterNode:
+        # passe en revue tous les champs du dictionnaire de réforme de payload.
+        # Ceux qui ne sont pas des dictionnaires seront mis à ce niveau dans ofdl
+        flatpayload = flattened_dict(self.payload)
+        for field_to_update, value in flatpayload.items():
+            reduce(getattr, field_to_update.split("."), parameters).update(period=self.period, value=value)
+        # Quand des champs complexes entreront en compte, un traitement ad hoc sera nécessaire pour ces champs
+        # et pour éviter qu'ils passent dans la moulinette ci-dessus
+
+        return parameters
+
+    def apply(self) -> None:
+        self.modify_parameters(modifier_function=self.modifier)
+
+
+if __name__ == "__main__":
+    test_flattened_dict()

--- a/dotation/reform.py
+++ b/dotation/reform.py
@@ -3,7 +3,7 @@ from openfisca_core.reforms import Reform  # type: ignore
 from openfisca_core.parameters import ParameterNode  # type: ignore
 from functools import reduce
 
-from utils_dict import flattened_dict
+from dotation.utils_dict import flattened_dict  # type: ignore
 
 
 class DotationReform(Reform):

--- a/dotation/reform.py
+++ b/dotation/reform.py
@@ -3,6 +3,7 @@ from openfisca_core.reforms import Reform  # type: ignore
 from openfisca_core.parameters import ParameterNode  # type: ignore
 from functools import reduce
 
+
 # Retourne un dictionnaire flattened à partir d'un nested dictionnaire
 def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
     res = {}

--- a/dotation/reform.py
+++ b/dotation/reform.py
@@ -1,9 +1,10 @@
-from openfisca_core import periods
+from openfisca_core import periods  # type: ignore
 from openfisca_core.reforms import Reform  # type: ignore
 from openfisca_core.parameters import ParameterNode  # type: ignore
 from functools import reduce
 
 from utils_dict import flattened_dict
+
 
 class DotationReform(Reform):
 
@@ -25,7 +26,3 @@ class DotationReform(Reform):
 
     def apply(self) -> None:
         self.modify_parameters(modifier_function=self.modifier)
-
-
-if __name__ == "__main__":
-    test_flattened_dict()

--- a/dotation/simulation.py
+++ b/dotation/simulation.py
@@ -1,0 +1,58 @@
+from openfisca_core.simulation_builder import SimulationBuilder  # type: ignore
+from load_dgcl_data import load_dgcl_file
+# Actually runs the simulations
+from openfisca_france_dotations_locales import CountryTaxBenefitSystem  # type: ignore
+from reform import DotationReform
+
+
+def simulation_from_dgcl_csv(period, data, tbs):
+    sb = SimulationBuilder()
+    sb.create_entities(tbs)
+    sb.declare_person_entity("commune", data.index)
+    simulation = sb.build(tbs)
+    for champ_openfisca in data.columns:
+        if " " not in champ_openfisca:  # oui c'est comme ça que je checke
+            # qu'une variable es openfisca ne me jugez pas
+            simulation.set_input(
+                champ_openfisca,
+                period,
+                data[champ_openfisca],
+            )
+    return simulation
+
+
+# outputte un dataframe qui contient :
+# l'output normal de load_
+# prend un dictionnaire de reformes (apres, eventuellement PLF)
+
+def resultfromreforms(dict_ref=None, to_compute_res=("dsr_eligible_fraction_bourg_centre", "dsr_eligible_fraction_perequation", "dsr_eligible_fraction_cible")):
+    PERIOD = "2020"
+    # some of these can be preloaded in memory to improve performance.
+    DATA = load_dgcl_file()
+    TBS = CountryTaxBenefitSystem()
+    dict_sims = {"avant": simulation_from_dgcl_csv(PERIOD, DATA, TBS)}
+    # création d'un dictionnaire contenant une simulation par output
+    if dict_ref is not None:
+        for nom_scenario, reforme_scenario in dict_ref.items():
+            TBS_Modified = DotationReform(TBS, reforme_scenario)
+            dict_sims[nom_scenario] = simulation_from_dgcl_csv(PERIOD, DATA, TBS_Modified)
+    # stockage des résulats dans un dataframe
+    for nom_scenario, sim in dict_sims.items():
+        for champ in to_compute_res:
+            DATA[champ + "_" + nom_scenario] = sim.calculate(champ, PERIOD)
+    return DATA
+
+
+if __name__ == "__main__":
+    payload_example = {
+        "dgf": {
+            "dotation_solidarite_rurale": {
+                "cible": {
+                    "eligibilite": {
+                        "seuil_classement": 23
+                    }
+                }
+            }
+        }
+    }
+    print(resultfromreforms({"apres": payload_example}))

--- a/dotation/utils_dict.py
+++ b/dotation/utils_dict.py
@@ -1,7 +1,4 @@
-
 # Retourne un dictionnaire flattened à partir d'un nested dictionnaire
-
-
 def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
     res = {}
     pc = [prechain] if len(prechain) else []
@@ -27,13 +24,6 @@ def unflattened_dict(dict_to_traverse, delimiter="."):
     return res
 
 
-def test_flattened_dict():
-    a = {"a": {"b": {"c": 3, "d": {"e": 4, "f": "chaton"}}}}
-    b = {"a.b.c": 3, "a.b.d.e": 4, "a.b.d.f": "chaton"}
-    assert(flattened_dict(a) == b)
-    assert(unflattened_dict(b) == a)
-
-
 def translate_dict(dict_to_translate, table_transcription):
     flattened_dict_pretranslation = flattened_dict(dict_to_translate)
     flattened_dict_posttranslation = {}
@@ -44,45 +34,3 @@ def translate_dict(dict_to_translate, table_transcription):
             new_key = k
         flattened_dict_posttranslation[new_key] = v
     return unflattened_dict(flattened_dict_posttranslation)
-
-
-def test_translate():
-    table_transcription = {"communes.dsr.eligibilite.popMax": "dotation_solidarite_rurale.seuil_nombre_habitants",
-                           "communes.dsr.eligibilite.popChefLieuMax": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_nombre_habitants_chef_lieu",
-                           "communes.dsr.bourgcentre.eligibilite.partPopCantonMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_part_population_canton",
-                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.partPopDepartementMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_part_population_dgf_agglomeration_departement",
-                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_agglomeration",
-                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popCommuneMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_maximum_commune_agglomeration",
-                           "communes.dsr.bourgcentre.eligibilite.exclusion.canton.popChefLieuMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_chef_lieu_de_canton",
-                           "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
-                           "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
-                           "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
-                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
-                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu", }
-
-    dict_example = {
-        "communes" : {
-            "dsr" : {
-                "cible": {
-                    "eligibilie": {
-                        "premieresCommunes": 10000
-                    }
-                }
-            }
-        }
-    }
-    dict_cible = {
-        "dotation_solidarite_rurale": {
-            "bourg_centre": {
-                "eligibilite": {
-                    "seuil_classement" : 10000
-                }
-            }
-        }
-    }
-    assert(translate_dict(dict_example, table_transcription) == dict_cible)
-
-
-if __name__ == "__main__":
-    test_flattened_dict()
-    test_translate()

--- a/dotation/utils_dict.py
+++ b/dotation/utils_dict.py
@@ -1,0 +1,87 @@
+
+# Retourne un dictionnaire flattened à partir d'un nested dictionnaire
+def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
+    res = {}
+    pc = [prechain] if len(prechain) else []
+    for k, v in dict_to_traverse.items():
+        if isinstance(v, dict):
+            res = {**res, **flattened_dict(v, prechain=delimiter.join(pc + [k]))}
+        else:
+            res[delimiter.join(pc + [k])] = v
+    return res
+
+
+# Retourne un nested dictionnaireà partir d'un dictionnaire flattened 
+def unflattened_dict(dict_to_traverse, prechain="", delimiter="."):
+    res = {}
+    pc = [prechain] if len(prechain) else []
+    for k, v in dict_to_traverse.items():
+        chemin=k.split(delimiter)
+        cur=res
+        for i in chemin[:-1]:
+            if i not in cur:
+                cur[i]={}
+            cur=cur[i]
+        cur[chemin[-1]] = v
+    return res
+
+def test_flattened_dict():
+    a = {"a": {"b": {"c": 3, "d": {"e": 4, "f": "chaton"}}}}
+    b = {"a.b.c": 3, "a.b.d.e": 4, "a.b.d.f": "chaton"}
+    assert(flattened_dict(a) == b)
+    assert(unflattened_dict(b)==a)
+
+
+def translate_dict(dict_to_translate, table_transcription):
+    flattened_dict_pretranslation = flattened_dict(dict_to_translate)
+    flattened_dict_posttranslation = {}
+    for k,v in flattened_dict_pretranslation.items():
+        if k in table_transcription:
+            new_key = table_transcription[k]
+        else:
+            new_key = k
+        flattened_dict_posttranslation[k] = v
+    return unflattened_dict(flattened_dict_posttranslation)
+
+
+
+def test_translate():
+    table_transcription = {"communes.dsr.eligibilite.popMax": "dotation_solidarite_rurale.seuil_nombre_habitants",
+    "communes.dsr.eligibilite.popChefLieuMax": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_nombre_habitants_chef_lieu",
+    "communes.dsr.bourgcentre.eligibilite.partPopCantonMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_part_population_canton",
+    "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.partPopDepartementMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_part_population_dgf_agglomeration_departement",
+    "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_agglomeration",
+    "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popCommuneMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_maximum_commune_agglomeration",
+    "communes.dsr.bourgcentre.eligibilite.exclusion.canton.popChefLieuMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_chef_lieu_de_canton",
+    "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
+    "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
+    "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
+    "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
+    "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu",}
+
+    dict_example = {
+        "communes" : {
+            "dsr" : {
+                "cible":{
+                    "eligibilie":{
+                        "premieresCommunes": 10000
+                    }
+                }
+            }
+        }
+    }
+    dict_cible = {
+        "dotation_solidarite_rurale": {
+            "bourg_centre": {
+                "eligibilite": {
+                    "seuil_classement" : 10000
+                }
+            }
+        }
+    }
+    assert(translate_dict(dict_example, table_transcription) == dict_cible)
+
+if __name__=="__main__":
+    test_flattened_dict()
+    test_translate()
+

--- a/dotation/utils_dict.py
+++ b/dotation/utils_dict.py
@@ -1,5 +1,7 @@
 
 # Retourne un dictionnaire flattened à partir d'un nested dictionnaire
+
+
 def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
     res = {}
     pc = [prechain] if len(prechain) else []
@@ -11,59 +13,58 @@ def flattened_dict(dict_to_traverse, prechain="", delimiter="."):
     return res
 
 
-# Retourne un nested dictionnaireà partir d'un dictionnaire flattened 
-def unflattened_dict(dict_to_traverse, prechain="", delimiter="."):
+# Retourne un nested dictionnaireà partir d'un dictionnaire flattened
+def unflattened_dict(dict_to_traverse, delimiter="."):
     res = {}
-    pc = [prechain] if len(prechain) else []
     for k, v in dict_to_traverse.items():
-        chemin=k.split(delimiter)
-        cur=res
+        chemin = k.split(delimiter)
+        cur = res
         for i in chemin[:-1]:
             if i not in cur:
-                cur[i]={}
-            cur=cur[i]
+                cur[i] = {}
+            cur = cur[i]
         cur[chemin[-1]] = v
     return res
+
 
 def test_flattened_dict():
     a = {"a": {"b": {"c": 3, "d": {"e": 4, "f": "chaton"}}}}
     b = {"a.b.c": 3, "a.b.d.e": 4, "a.b.d.f": "chaton"}
     assert(flattened_dict(a) == b)
-    assert(unflattened_dict(b)==a)
+    assert(unflattened_dict(b) == a)
 
 
 def translate_dict(dict_to_translate, table_transcription):
     flattened_dict_pretranslation = flattened_dict(dict_to_translate)
     flattened_dict_posttranslation = {}
-    for k,v in flattened_dict_pretranslation.items():
+    for k, v in flattened_dict_pretranslation.items():
         if k in table_transcription:
             new_key = table_transcription[k]
         else:
             new_key = k
-        flattened_dict_posttranslation[k] = v
+        flattened_dict_posttranslation[new_key] = v
     return unflattened_dict(flattened_dict_posttranslation)
-
 
 
 def test_translate():
     table_transcription = {"communes.dsr.eligibilite.popMax": "dotation_solidarite_rurale.seuil_nombre_habitants",
-    "communes.dsr.eligibilite.popChefLieuMax": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_nombre_habitants_chef_lieu",
-    "communes.dsr.bourgcentre.eligibilite.partPopCantonMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_part_population_canton",
-    "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.partPopDepartementMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_part_population_dgf_agglomeration_departement",
-    "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_agglomeration",
-    "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popCommuneMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_maximum_commune_agglomeration",
-    "communes.dsr.bourgcentre.eligibilite.exclusion.canton.popChefLieuMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_chef_lieu_de_canton",
-    "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
-    "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
-    "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
-    "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
-    "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu",}
+                           "communes.dsr.eligibilite.popChefLieuMax": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_nombre_habitants_chef_lieu",
+                           "communes.dsr.bourgcentre.eligibilite.partPopCantonMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_part_population_canton",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.partPopDepartementMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_part_population_dgf_agglomeration_departement",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_agglomeration",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popCommuneMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_maximum_commune_agglomeration",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.canton.popChefLieuMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_chef_lieu_de_canton",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
+                           "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
+                           "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
+                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
+                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu", }
 
     dict_example = {
         "communes" : {
             "dsr" : {
-                "cible":{
-                    "eligibilie":{
+                "cible": {
+                    "eligibilie": {
                         "premieresCommunes": 10000
                     }
                 }
@@ -81,7 +82,7 @@ def test_translate():
     }
     assert(translate_dict(dict_example, table_transcription) == dict_cible)
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     test_flattened_dict()
     test_translate()
-

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -272,18 +272,5 @@ components:
     dotations:
       type: object
       properties:
-        reforme:
-          type: object
-          properties:
-            dotations:
-              type: object
-              properties:
-                montants:
-                  type: object
-                  properties:
-                    dgf:
-                      type: number
-                communes:
-                  type: object
-        description_cas_types:
+        dotations:
           type: object

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -272,5 +272,18 @@ components:
     dotations:
       type: object
       properties:
-        dotations:
+        reforme:
+          type: object
+          properties:
+            dotations:
+              type: object
+              properties:
+                montants:
+                  type: object
+                  properties:
+                    dgf:
+                      type: number
+                communes:
+                  type: object
+        description_cas_types:
           type: object

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -79,6 +79,19 @@ paths:
             description: L'usager a pu étre authentifié·e
           '401':
             description: L'usager n'est pas dans la liste validée par l'INSEE
+  /dotations:
+    post:
+      summary: Demande le calcul de l'impact des articles de loi sur les dotations aux collectivités.
+      operationId: server.handlers.Dotations.simule_dotations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/dotations'
+      responses:
+          '201':
+            description: Résultat de la simulation des dotations aux collectivités.
 components:
   schemas:
     Greetings:
@@ -256,3 +269,8 @@ components:
       properties:
         email:
           type: string
+    dotations:
+      type: object
+      properties:
+        dotations:
+          type: object

--- a/server/handlers/__init__.py
+++ b/server/handlers/__init__.py
@@ -1,2 +1,3 @@
 from .cas_types import CasTypes, SimulationRunner  # noqa
 from .welcome import Welcome  # noqa
+from .dotations import Dotations

--- a/server/handlers/__init__.py
+++ b/server/handlers/__init__.py
@@ -1,3 +1,3 @@
 from .cas_types import CasTypes, SimulationRunner  # noqa
 from .welcome import Welcome  # noqa
-from .dotations import Dotations
+from .dotations import Dotations  # noqa

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -1,0 +1,13 @@
+class Dotations(object):
+
+    def home(**params: dict) -> tuple:
+        request_body = params["body"]
+
+        # vérifier le format
+        if "dotations" not in request_body:
+            return {"Error": "Missing 'dotations' field in request body."}, 400
+
+        # calculer
+
+        # constuire la réponse
+        return {"hello": "coucou"}, 200

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -1,5 +1,6 @@
 from Simulation_engine.simulate_dotations import simulate
 
+
 class Dotations(object):
 
     def simule_dotations(**params: dict) -> tuple:

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -1,3 +1,5 @@
+from Simulation_engine.simulate_dotations import simulate
+
 class Dotations(object):
 
     def simule_dotations(**params: dict) -> tuple:
@@ -8,6 +10,7 @@ class Dotations(object):
             return {"Error": "Missing 'dotations' field in request body."}, 400
 
         # calculer
+        simulation_result = simulate(request_body)
 
         # constuire la réponse
-        return {"hello": "coucou"}, 200
+        return simulation_result, 200

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -3,12 +3,26 @@ from Simulation_engine.simulate_dotations import simulate
 
 class Dotations(object):
 
+    def check_field(self, node, field_name):
+        if "field_name" not in node:
+            return {
+                "Error": "Missing '{0}' field in request body. Parent node is: {1}".format(
+                    field_name, node
+                    )
+                }, 400
+        pass
+
+    def check_request_format(self, request_body):
+        self.check_field(request_body, "reforme")
+        self.check_field(request_body["reforme"], "dotations")
+        self.check_field(request_body["reforme"]["dotations"], "montants")
+        self.check_field(request_body["reforme"]["dotations"]["montants"], "dgf")
+        self.check_field(request_body["reforme"]["dotations"], "communes")
+        self.check_field(request_body, "description_cas_types")
+
     def simule_dotations(**params: dict) -> tuple:
         request_body = params["body"]
-
-        # vérifier le format
-        if "dotations" not in request_body:
-            return {"Error": "Missing 'dotations' field in request body."}, 400
+        self.check_request_format(request_body)
 
         # calculer
         simulation_result = simulate(request_body)

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -3,26 +3,12 @@ from Simulation_engine.simulate_dotations import simulate
 
 class Dotations(object):
 
-    def check_field(self, node, field_name):
-        if "field_name" not in node:
-            return {
-                "Error": "Missing '{0}' field in request body. Parent node is: {1}".format(
-                    field_name, node
-                    )
-                }, 400
-        pass
-
-    def check_request_format(self, request_body):
-        self.check_field(request_body, "reforme")
-        self.check_field(request_body["reforme"], "dotations")
-        self.check_field(request_body["reforme"]["dotations"], "montants")
-        self.check_field(request_body["reforme"]["dotations"]["montants"], "dgf")
-        self.check_field(request_body["reforme"]["dotations"], "communes")
-        self.check_field(request_body, "description_cas_types")
-
     def simule_dotations(**params: dict) -> tuple:
         request_body = params["body"]
-        self.check_request_format(request_body)
+
+        # vérifier le format
+        if "dotations" not in request_body:
+            return {"Error": "Missing 'dotations' field in request body."}, 400
 
         # calculer
         simulation_result = simulate(request_body)

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -1,6 +1,6 @@
 class Dotations(object):
 
-    def home(**params: dict) -> tuple:
+    def simule_dotations(**params: dict) -> tuple:
         request_body = params["body"]
 
         # vérifier le format

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -1,5 +1,29 @@
 from Simulation_engine.simulate_dotations import simulate
 
+# Checks whether all dictionnaries in the model exist in the target dict.
+# Returns True or False, and the problematic field
+
+
+def check_keys_dict(dict_to_check, model):
+    for k, v in model.items():
+        if k not in dict_to_check:  # key does not exist
+            return False, k
+        if isinstance(v, dict):
+            if not isinstance(dict_to_check[k], dict):  # should be a dict but is not
+                return False, k
+            res_child, node_err = check_keys_dict(dict_to_check[k], v)
+            if not res_child:
+                return False, ".".join([k, node_err])
+
+    return True, "All required keys are in the checked dictionary"
+
+
+def check_request_body(request_body):
+    required_dict = {"reforme": {"dotations": {"montants": {"dgf": None}, "communes": None}}}
+    result, errorfield = check_keys_dict(request_body, required_dict)
+    if not result:
+        return {"Error": "Missing required '{}' field in request body.".format(errorfield)}, 400
+
 
 class Dotations(object):
 
@@ -7,8 +31,9 @@ class Dotations(object):
         request_body = params["body"]
 
         # vérifier le format
-        if "dotations" not in request_body:
-            return {"Error": "Missing 'dotations' field in request body."}, 400
+        check_result = check_request_body(request_body)
+        if check_result is not None:
+            return check_result
 
         # calculer
         simulation_result = simulate(request_body)

--- a/tests/dotation/test_reform.py
+++ b/tests/dotation/test_reform.py
@@ -1,0 +1,41 @@
+from dotation.reform import DotationReform
+from openfisca_france_dotations_locales import CountryTaxBenefitSystem  # type: ignore
+
+
+
+def test_correct_reform_applied():
+    tbs = CountryTaxBenefitSystem()
+    value_to_set = 793
+    description_reforme = {
+        "dgf":{
+            "dotation_solidarite_rurale": {
+                "cible": {
+                    "eligibilite": {
+                        "seuil_classement" : value_to_set
+                    }
+                }
+            }
+        }
+    }
+    tbs_modified = DotationReform(tbs, description_reforme)
+
+    print(tbs_modified.get_parameters_at_instant("2020-01-01")["dotation_solidarite_rurale"]["cible"]["eligibilite"]["seuil_classement"]==793)
+
+def test_modif_nothing():
+    tbs = CountryTaxBenefitSystem()
+    value_to_set = 793
+    description_reforme = {
+        "dgf":{
+            "nimportequoi": {
+                "anythinggoes": {
+                    "memepasdedashcase": 168
+                }
+            }
+        }
+    }
+    tbs_modified = DotationReform(tbs, description_reforme)
+
+    print(tbs_modified.get_parameters_at_instant("2020-01-01")==tbs_modified.get_parameters_at_instant("2020-01-01"))
+
+
+test_modif_nothing()

--- a/tests/dotation/test_reform.py
+++ b/tests/dotation/test_reform.py
@@ -1,13 +1,12 @@
-from dotation.reform import DotationReform
+from dotation.reform import DotationReform  # type: ignore
 from openfisca_france_dotations_locales import CountryTaxBenefitSystem  # type: ignore
-
 
 
 def test_correct_reform_applied():
     tbs = CountryTaxBenefitSystem()
     value_to_set = 793
     description_reforme = {
-        "dgf":{
+        "dgf": {
             "dotation_solidarite_rurale": {
                 "cible": {
                     "eligibilite": {
@@ -19,23 +18,4 @@ def test_correct_reform_applied():
     }
     tbs_modified = DotationReform(tbs, description_reforme)
 
-    print(tbs_modified.get_parameters_at_instant("2020-01-01")["dotation_solidarite_rurale"]["cible"]["eligibilite"]["seuil_classement"]==793)
-
-def test_modif_nothing():
-    tbs = CountryTaxBenefitSystem()
-    value_to_set = 793
-    description_reforme = {
-        "dgf":{
-            "nimportequoi": {
-                "anythinggoes": {
-                    "memepasdedashcase": 168
-                }
-            }
-        }
-    }
-    tbs_modified = DotationReform(tbs, description_reforme)
-
-    print(tbs_modified.get_parameters_at_instant("2020-01-01")==tbs_modified.get_parameters_at_instant("2020-01-01"))
-
-
-test_modif_nothing()
+    print(tbs_modified.get_parameters_at_instant("2020-01-01")["dotation_solidarite_rurale"]["cible"]["eligibilite"]["seuil_classement"] == value_to_set)

--- a/tests/dotation/test_utils_dict.py
+++ b/tests/dotation/test_utils_dict.py
@@ -12,7 +12,7 @@ def test_translate_conditions_reelles():
                            "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
                            "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
                            "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
-                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
+                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_potentiel_financier",
                            "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu", }
 
     dict_example = {

--- a/tests/dotation/test_utils_dict.py
+++ b/tests/dotation/test_utils_dict.py
@@ -1,0 +1,60 @@
+from dotation.utils_dict import translate_dict, flattened_dict, unflattened_dict
+
+
+def test_translate_conditions_reelles():
+    table_transcription = {"communes.dsr.eligibilite.popMax": "dotation_solidarite_rurale.seuil_nombre_habitants",
+                           "communes.dsr.eligibilite.popChefLieuMax": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_nombre_habitants_chef_lieu",
+                           "communes.dsr.bourgcentre.eligibilite.partPopCantonMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.seuil_part_population_canton",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.partPopDepartementMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_part_population_dgf_agglomeration_departement",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_agglomeration",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.agglomeration.popCommuneMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_maximum_commune_agglomeration",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.canton.popChefLieuMin": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_population_dgf_chef_lieu_de_canton",
+                           "communes.dsr.bourgcentre.eligibilite.exclusion.potentielFinancierParHab.rapportPotentielFinancierMoyenParHab": "dotation_solidarite_rurale.bourg_centre.eligibilite.exclusion.seuil_rapport_pfi_10000",
+                           "communes.dsr.bourgcentre.attribution.plafonnementPopulation": "population.plafond_dgf",
+                           "communes.dsr.cible.eligibilite.premieresCommunes": "dotation_solidarite_rurale.cible.eligibilite.seuil_classement",
+                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_pot_fin",
+                           "communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenuParHab": "dotation_solidarite_rurale.cible.eligibilite.indice_synthetique.poids_revenu", }
+
+    dict_example = {
+        "communes" : {
+            "dsr" : {
+                "cible": {
+                    "eligibilite": {
+                        "premieresCommunes": 10000
+                    }
+                }
+            }
+        }
+    }
+    dict_cible = {
+        "dotation_solidarite_rurale": {
+            "cible": {
+                "eligibilite": {
+                    "seuil_classement" : 10000
+                }
+            }
+        }
+    }
+    translated = translate_dict(dict_example, table_transcription)
+    assert(translated == dict_cible)
+
+
+def test_flattened_dict():
+    a = {"a": {"b": {"c": 3, "d": {"e": 4, "f": "chaton"}}}}
+    b = {"a.b.c": 3, "a.b.d.e": 4, "a.b.d.f": "chaton"}
+    assert(flattened_dict(a) == b)
+    assert(unflattened_dict(b) == a)
+
+
+def test_translate_unchanged():
+    dict_trans = {"a": "A", "b": "B"}
+    before_translation = {"a": {"b" : 3}}
+    after_translation = {"a": {"b" : 3}}
+    assert(translate_dict(before_translation, dict_trans) == after_translation)
+
+
+def test_translate_basic():
+    dict_trans = {"a": "A", "b": "B", "d.e": "D.E"}
+    before_translation = {"a" : 1, "b" : 2, "c": 3, "d": {"e": 4, "f": 5}}
+    after_translation = {"A" : 1, "B" : 2, "c": 3, "D": {"E": 4}, "d": {"f": 5}}
+    assert(translate_dict(before_translation, dict_trans) == after_translation)

--- a/tests/dotation/test_utils_dict.py
+++ b/tests/dotation/test_utils_dict.py
@@ -1,4 +1,4 @@
-from dotation.utils_dict import translate_dict, flattened_dict, unflattened_dict
+from dotation.utils_dict import translate_dict, flattened_dict, unflattened_dict  # type: ignore
 
 
 def test_translate_conditions_reelles():

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -3,10 +3,10 @@ import json
 
 
 def test_dotations_request_body_error(client, headers):
-    request = {}
+    empty_request = {}
 
     response_function = partial(client.post, "dotations", headers=headers)
-    response = response_function(data=json.dumps(request))
+    response = response_function(data=json.dumps(empty_request))
 
     assert response.status_code == 400
     assert "Error" in json.loads(response.data)
@@ -14,10 +14,18 @@ def test_dotations_request_body_error(client, headers):
 
 def test_dotations(client, headers):
     request = {
-        "dotations": {}
+        "reforme": {
+            "dotations": {
+                "montants": {
+                    "dgf": 42
+                },
+                "communes": {}
+            }
+        },
+        "description_cas_types": {}
     }
 
     response_function = partial(client.post, "dotations", headers=headers)
     response = response_function(data=json.dumps(request))
 
-    assert response.status_code == 200
+    assert response.status_code == 200, json.loads(response.data)

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -14,7 +14,12 @@ def test_dotations_request_body_error(client, headers):
 
 def test_dotations(client, headers):
     request = {
-        "dotations": {}
+        "reforme": {
+            "dotations": {
+                "montants": {"dgf": 16},
+                "communes": {}
+            }
+        }
     }
 
     response_function = partial(client.post, "dotations", headers=headers)

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -10,3 +10,14 @@ def test_dotations_request_body_error(client, headers):
 
     assert response.status_code == 400
     assert "Error" in json.loads(response.data)
+
+
+def test_dotations(client, headers):
+    request = {
+        "dotations": {}
+    }
+
+    response_function = partial(client.post, "dotations", headers=headers)
+    response = response_function(data=json.dumps(request))
+
+    assert response.status_code == 200

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -3,10 +3,10 @@ import json
 
 
 def test_dotations_request_body_error(client, headers):
-    empty_request = {}
+    request = {}
 
     response_function = partial(client.post, "dotations", headers=headers)
-    response = response_function(data=json.dumps(empty_request))
+    response = response_function(data=json.dumps(request))
 
     assert response.status_code == 400
     assert "Error" in json.loads(response.data)
@@ -14,18 +14,10 @@ def test_dotations_request_body_error(client, headers):
 
 def test_dotations(client, headers):
     request = {
-        "reforme": {
-            "dotations": {
-                "montants": {
-                    "dgf": 42
-                },
-                "communes": {}
-            }
-        },
-        "description_cas_types": {}
+        "dotations": {}
     }
 
     response_function = partial(client.post, "dotations", headers=headers)
     response = response_function(data=json.dumps(request))
 
-    assert response.status_code == 200, json.loads(response.data)
+    assert response.status_code == 200

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -2,10 +2,11 @@ from functools import partial
 import json
 
 
-def test_dotations(client, headers):
+def test_dotations_request_body_error(client, headers):
     request = {}
 
     response_function = partial(client.post, "dotations", headers=headers)
     response = response_function(data=json.dumps(request))
 
     assert response.status_code == 400
+    assert "Error" in json.loads(response.data)

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -1,0 +1,11 @@
+from functools import partial
+import json
+
+
+def test_dotations(client, headers):
+    request = {}
+
+    response_function = partial(client.post, "dotations", headers=headers)
+    response = response_function(data=json.dumps(request))
+
+    assert response.status_code == 400


### PR DESCRIPTION
introduit un moteur de calcul sur le serveur qui fait des trucs sympas.

Nécessite openfisca-france-dotations-locales

Pas branché au serveur pour l'instant, juste des petits scripts qui s'exécutent à partir de leur dossier.

5 fichiers sont créés, pour l'instant tous dans le dossier dotations :
- reforme : reforme openfisca-ique
- load_data_dgcl : transforme en dataframe le fichier format DGCL
- simulation : déjà plus fun : calcule les résultats au format dataframe de variables spécifiées par l'utilisateur
- impact : encore plus fun : c'est l'embryon du moteur de calcul qui calcule les résultats jolis à partir de l'output de la simulation
- compare_with_dgcl : calcule (mais pour l'instant on n'en fait rien) l'écart avec les données de la DGCL... Je ne spoilerai pas le résultat