### PR TITLE
Montants de la DSR

### DIFF
--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -52,11 +52,14 @@ def simulate(request_body, prefix_dsr_eligible):
     reforme = format_reforme_openfisca(request_body["reforme"])
     df_results: DataFrame = resultfromreforms({"amendement" : reforme}, to_compute)
 
+    prefix_montant = "dsr_montant_"
+
     for scenario in ["base", "amendement"]:
         df_results[prefix_dsr_eligible + scenario] = (
             df_results["dsr_eligible_fraction_bourg_centre" + "_" + scenario]
             | df_results["dsr_eligible_fraction_perequation" + "_" + scenario]
             | df_results["dsr_eligible_fraction_cible" + "_" + scenario]
         )
+        df_results[prefix_montant + scenario] = df_results["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + scenario]
 
     return df_results

--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -39,7 +39,7 @@ def format_reforme_openfisca(reforme_a_traduire):
     return {"dgf": translate_dict(ref, TABLE_LEXIMPACT_TO_OFDL)}
 
 
-def simulate(request_body, prefix_dsr_eligible):
+def simulate(request_body, prefix_dsr_eligible, prefix_montant):
     variables_nombre_communes = [
         "dsr_eligible_fraction_bourg_centre",
         "dsr_eligible_fraction_perequation",
@@ -51,8 +51,6 @@ def simulate(request_body, prefix_dsr_eligible):
 
     reforme = format_reforme_openfisca(request_body["reforme"])
     df_results: DataFrame = resultfromreforms({"amendement" : reforme}, to_compute)
-
-    prefix_montant = "dsr_montant_"
 
     for scenario in ["base", "amendement"]:
         df_results[prefix_dsr_eligible + scenario] = (

--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -39,7 +39,7 @@ def format_reforme_openfisca(reforme_a_traduire):
     return {"dgf": translate_dict(ref, TABLE_LEXIMPACT_TO_OFDL)}
 
 
-def simulate(request_body, prefix_dsr_eligible, prefix_montant):
+def simulate(request_body, prefix_dsr_eligible, prefix_dsr_montant):
     variables_nombre_communes = [
         "dsr_eligible_fraction_bourg_centre",
         "dsr_eligible_fraction_perequation",
@@ -58,6 +58,6 @@ def simulate(request_body, prefix_dsr_eligible, prefix_montant):
             | df_results["dsr_eligible_fraction_perequation" + "_" + scenario]
             | df_results["dsr_eligible_fraction_cible" + "_" + scenario]
         )
-        df_results[prefix_montant + scenario] = df_results[[nom_variable + "_" + scenario for nom_variable in variables_montants_fractions_dsr]].sum(axis="columns")
+        df_results[prefix_dsr_montant + scenario] = df_results[[nom_variable + "_" + scenario for nom_variable in variables_montants_fractions_dsr]].sum(axis="columns")
 
     return df_results

--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -46,9 +46,9 @@ def simulate(request_body, prefix_dsr_eligible, prefix_montant):
         "dsr_eligible_fraction_cible"
     ]
     variables_aggregations = ["potentiel_financier"]
-    variables_montants = ["dsr_montant_hors_garanties_fraction_bourg_centre"]
-    to_compute = variables_nombre_communes + variables_aggregations + variables_montants
-
+    fractions_dsr = ["bourg_centre", "perequation", "cible"]
+    variables_montants_fractions_dsr = ["dsr_montant_hors_garanties_fraction_" + nom_fraction for nom_fraction in fractions_dsr]
+    to_compute = variables_nombre_communes + variables_aggregations + variables_montants_fractions_dsr
     reforme = format_reforme_openfisca(request_body["reforme"])
     df_results: DataFrame = resultfromreforms({"amendement" : reforme}, to_compute)
 
@@ -58,6 +58,6 @@ def simulate(request_body, prefix_dsr_eligible, prefix_montant):
             | df_results["dsr_eligible_fraction_perequation" + "_" + scenario]
             | df_results["dsr_eligible_fraction_cible" + "_" + scenario]
         )
-        df_results[prefix_montant + scenario] = df_results["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + scenario]
+        df_results[prefix_montant + scenario] = df_results[[nom_variable + "_" + scenario for nom_variable in variables_montants_fractions_dsr]].sum(axis="columns")
 
     return df_results

--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -46,7 +46,8 @@ def simulate(request_body, prefix_dsr_eligible):
         "dsr_eligible_fraction_cible"
     ]
     variables_aggregations = ["potentiel_financier"]
-    to_compute = variables_nombre_communes + variables_aggregations
+    variables_montants = ["dsr_montant_hors_garanties_fraction_bourg_centre"]
+    to_compute = variables_nombre_communes + variables_aggregations + variables_montants
 
     reforme = format_reforme_openfisca(request_body["reforme"])
     df_results: DataFrame = resultfromreforms({"amendement" : reforme}, to_compute)

--- a/dotations/impact.py
+++ b/dotations/impact.py
@@ -8,16 +8,18 @@ def get_cas_types_codes_insee():
     return ["76384", "76214"]  # sera paramétrable par l'usager
 
 
-def build_response_dsr_cas_types(scenario, df_results, prefix_dsr_eligible):
+def build_response_dsr_cas_types(scenario, df_results, prefix_dsr_eligible, prefix_dsr_montant):
     # [scenario_api]["dotations"]["communes"]["dsr"]
     # > ["communes"]
     response = []
-
     code_comm = "Informations générales - Code INSEE de la commune"
     communes_cas_types = get_cas_types_codes_insee()
     for cas_type in communes_cas_types:
-        cas_type_eligible = bool(df_results[df_results[code_comm].astype(str) == cas_type][prefix_dsr_eligible + scenario].values[0])
-        response += [{"code" : cas_type, "eligible": cas_type_eligible}]
+        res_cas_type = df_results[df_results[code_comm].astype(str) == cas_type]
+        pop_cas_type = res_cas_type["population_insee"].values[0]
+        cas_type_eligible = bool(res_cas_type[prefix_dsr_eligible + scenario].values[0])
+        montant_dsr_cas_type = res_cas_type[prefix_dsr_montant + scenario].values[0]
+        response += [{"code" : cas_type, "eligible": cas_type_eligible, "dotationParHab": float(montant_dsr_cas_type / pop_cas_type)}]
 
     return response
 
@@ -64,10 +66,10 @@ def build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible):
     return res_strates
 
 
-def build_response_dsr(scenario: str, df_results: DataFrame, prefix_dsr_eligible: str) -> dict:
+def build_response_dsr(scenario: str, df_results: DataFrame, prefix_dsr_eligible: str, prefix_dsr_montant: str) -> dict:
     eligibilites = build_response_dsr_eligibilites(scenario, df_results, prefix_dsr_eligible)
     return {
-        "communes": build_response_dsr_cas_types(scenario, df_results, prefix_dsr_eligible),
+        "communes": build_response_dsr_cas_types(scenario, df_results, prefix_dsr_eligible, prefix_dsr_montant),
         **eligibilites,
         "strates": build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible)
     }

--- a/dotations/impact.py
+++ b/dotations/impact.py
@@ -37,7 +37,7 @@ def build_response_dsr_eligibilites(scenario, df_results, prefix_dsr_eligible):
     return response
 
 
-def build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible):
+def build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible, prefix_dsr_montant):
     # [scenario_api]["dotations"]["communes"]["dsr"]
     # > ["strates"]
 
@@ -52,6 +52,7 @@ def build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible):
         resultats_agreges_bornes[id_borne]["population_insee"] = int(df_strate["population_insee"].sum())
         resultats_agreges_bornes[id_borne]["potentiel_financier"] = float(df_strate["potentiel_financier" + "_" + scenario].sum())
         resultats_agreges_bornes[id_borne]["eligibles_dsr"] = int(df_strate[prefix_dsr_eligible + scenario].sum())
+        resultats_agreges_bornes[id_borne]["montant_dsr"] = int(df_strate[prefix_dsr_montant + scenario].sum())
 
     res_strates = [{} for borne in BORNES_STRATES[:-1]]
     for id_borne in range(len(BORNES_STRATES) - 1):
@@ -62,6 +63,8 @@ def build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible):
         res_strates[id_borne]["potentielFinancierMoyenParHabitant"] = pot_strate / pop_strate
         nb_elig_strate = resultats_agreges_bornes[id_borne]["eligibles_dsr"] - resultats_agreges_bornes[id_borne + 1]["eligibles_dsr"]
         res_strates[id_borne]["eligibles"] = nb_elig_strate
+        res_strates[id_borne]["dotationMoyenneParHab"] = (resultats_agreges_bornes[id_borne]["montant_dsr"] - resultats_agreges_bornes[id_borne + 1]["montant_dsr"]) / pop_strate
+        res_strates[id_borne]["partDotationTotale"] = ((resultats_agreges_bornes[id_borne]["montant_dsr"] - resultats_agreges_bornes[id_borne + 1]["montant_dsr"]) / resultats_agreges_bornes[0]["montant_dsr"]) if resultats_agreges_bornes[0]["montant_dsr"] else 0
 
     return res_strates
 
@@ -71,5 +74,5 @@ def build_response_dsr(scenario: str, df_results: DataFrame, prefix_dsr_eligible
     return {
         "communes": build_response_dsr_cas_types(scenario, df_results, prefix_dsr_eligible, prefix_dsr_montant),
         **eligibilites,
-        "strates": build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible)
+        "strates": build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible, prefix_dsr_montant)
     }

--- a/dotations/impact.py
+++ b/dotations/impact.py
@@ -64,7 +64,9 @@ def build_response_dsr_strates(scenario, df_results, prefix_dsr_eligible, prefix
         nb_elig_strate = resultats_agreges_bornes[id_borne]["eligibles_dsr"] - resultats_agreges_bornes[id_borne + 1]["eligibles_dsr"]
         res_strates[id_borne]["eligibles"] = nb_elig_strate
         res_strates[id_borne]["dotationMoyenneParHab"] = (resultats_agreges_bornes[id_borne]["montant_dsr"] - resultats_agreges_bornes[id_borne + 1]["montant_dsr"]) / pop_strate
-        res_strates[id_borne]["partDotationTotale"] = ((resultats_agreges_bornes[id_borne]["montant_dsr"] - resultats_agreges_bornes[id_borne + 1]["montant_dsr"]) / resultats_agreges_bornes[0]["montant_dsr"]) if resultats_agreges_bornes[0]["montant_dsr"] else 0
+        res_strates[id_borne]["partDotationTotale"] = (
+            (resultats_agreges_bornes[id_borne]["montant_dsr"] - resultats_agreges_bornes[id_borne + 1]["montant_dsr"]) / resultats_agreges_bornes[0]["montant_dsr"]
+        ) if resultats_agreges_bornes[0]["montant_dsr"] else 0
 
     return res_strates
 

--- a/dotations/load_dgcl_data.py
+++ b/dotations/load_dgcl_data.py
@@ -289,12 +289,9 @@ def adapt_dgcl_data(data):
     data[elig_bc_dgcl] = (data["Dotation de solidarité rurale Bourg-centre - Montant de la commune éligible"] > 0)
     data[elig_pq_dgcl] = (data["Dotation de solidarité rurale - Péréquation - Part Pfi (avant garantie CN)"] > 0)
     data[elig_cible_dgcl] = (data[rang_indice_synthetique] > 0) & (data[rang_indice_synthetique] <= 10000)
-
     # Au delà des colonnes traduites, on garde ces colonnes dans le dataframe de sortie.
-    # Pour comparer nos résultats aux résultats calculés, et pour garder des informations
-    # pour identifier la commune
-    actual_indice_synthetique = "Dotation de solidarité rurale - Cible - Indice synthétique"
-    autres_cols_interessantes = [code_comm, nom_comm, rang_indice_synthetique, actual_indice_synthetique, elig_bc_dgcl, elig_pq_dgcl, elig_cible_dgcl]
+    # Pour garder des informations pour identifier la commune
+    autres_cols_interessantes = [code_comm, nom_comm]
     data = data[autres_cols_interessantes + list(translation_cols.values())]
 
     # Renomme colonnes

--- a/dotations/load_dgcl_data.py
+++ b/dotations/load_dgcl_data.py
@@ -202,7 +202,6 @@ def get_dgcl_results(data):
     # les noms du fichier (à part pour leur code commune bien sûr)
     resultats_extraits = data[[code_comm]]
 
-
     # Ajout de variables qui n'existent pas à l'état brut dans le fichier :
 
     # L'éligibilité est déterminée en fonction de la présence ou non d'un versement non nul

--- a/dotations/load_dgcl_data.py
+++ b/dotations/load_dgcl_data.py
@@ -23,7 +23,9 @@ variables_openfisca_presentes_fichier = {
     'potentiel_financier': 'Potentiel fiscal et financier des communes - Potentiel financier',
     'potentiel_financier_par_habitant': 'Potentiel fiscal et financier des communes - Potentiel financier par habitant',
     'revenu_total': 'Dotation de solidarité urbaine - Revenu imposable des habitants de la commune',
-    'strate_demographique': 'Informations générales - Strate démographique Année N'
+    'strate_demographique': 'Informations générales - Strate démographique Année N',
+    'zrr':'Dotation de solidarité rurale - Bourg-centre - Commune située en ZRR',
+    'effort_fiscal':'Effort fiscal - Effort fiscal'
 }
 
 # A partir de l'adresse du tableau publié par la DGCL, produit un tableau contenant toutes les colonnes nécessaires
@@ -239,7 +241,7 @@ def adapt_dgcl_data(data):
     data.columns = [column if column not in invert_dict else invert_dict[column] for column in data.columns]
 
     # Passe les "booléens dgf" (oui/non) en booléens normaux
-    liste_columns_to_real_bool = ["bureau_centralisateur", "chef_lieu_arrondissement", "chef_lieu_departement_dans_agglomeration"]
+    liste_columns_to_real_bool = ["bureau_centralisateur", "chef_lieu_arrondissement","zrr", "chef_lieu_departement_dans_agglomeration"]
     for col in liste_columns_to_real_bool:
         data[col] = (data[col].str.contains(pat="oui", case=False))
 

--- a/dotations/load_dgcl_data.py
+++ b/dotations/load_dgcl_data.py
@@ -24,8 +24,8 @@ variables_openfisca_presentes_fichier = {
     'potentiel_financier_par_habitant': 'Potentiel fiscal et financier des communes - Potentiel financier par habitant',
     'revenu_total': 'Dotation de solidarité urbaine - Revenu imposable des habitants de la commune',
     'strate_demographique': 'Informations générales - Strate démographique Année N',
-    'zrr':'Dotation de solidarité rurale - Bourg-centre - Commune située en ZRR',
-    'effort_fiscal':'Effort fiscal - Effort fiscal'
+    'zrr': 'Dotation de solidarité rurale - Bourg-centre - Commune située en ZRR',
+    'effort_fiscal': 'Effort fiscal - Effort fiscal'
 }
 
 # A partir de l'adresse du tableau publié par la DGCL, produit un tableau contenant toutes les colonnes nécessaires
@@ -241,7 +241,7 @@ def adapt_dgcl_data(data):
     data.columns = [column if column not in invert_dict else invert_dict[column] for column in data.columns]
 
     # Passe les "booléens dgf" (oui/non) en booléens normaux
-    liste_columns_to_real_bool = ["bureau_centralisateur", "chef_lieu_arrondissement","zrr", "chef_lieu_departement_dans_agglomeration"]
+    liste_columns_to_real_bool = ["bureau_centralisateur", "chef_lieu_arrondissement", "zrr", "chef_lieu_departement_dans_agglomeration"]
     for col in liste_columns_to_real_bool:
         data[col] = (data[col].str.contains(pat="oui", case=False))
 

--- a/dotations/load_dgcl_data.py
+++ b/dotations/load_dgcl_data.py
@@ -25,7 +25,12 @@ variables_openfisca_presentes_fichier = {
     'revenu_total': 'Dotation de solidarité urbaine - Revenu imposable des habitants de la commune',
     'strate_demographique': 'Informations générales - Strate démographique Année N',
     'zrr': 'Dotation de solidarité rurale - Bourg-centre - Commune située en ZRR',
-    'effort_fiscal': 'Effort fiscal - Effort fiscal'
+    'effort_fiscal': 'Effort fiscal - Effort fiscal',
+    'longueur_voirie': 'Dotation de solidarité rurale - Péréquation - Longueur de voirie en mètres',
+    'zone_de_montagne': 'Dotation de solidarité rurale - Péréquation - Commune située en zone de montagne',
+    'insulaire': 'Dotation de solidarité rurale - Péréquation - Commune insulaire',
+    'superficie': 'Informations générales - Superficie 2019',
+    'population_enfants': 'Dotation de solidarité rurale - Péréquation - Population 3 à 16 ans',
 }
 
 # A partir de l'adresse du tableau publié par la DGCL, produit un tableau contenant toutes les colonnes nécessaires

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -41,7 +41,7 @@ class Dotations(object):
         # calculer
         prefix_dsr_eligible = "dsr_eligible_"
         prefix_dsr_montant = "dsr_montant_"
-        df_results = simulate(request_body, prefix_dsr_eligible)
+        df_results = simulate(request_body, prefix_dsr_eligible, prefix_dsr_montant)
 
         # constuire la réponse
         simulation_result = {

--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -40,6 +40,7 @@ class Dotations(object):
 
         # calculer
         prefix_dsr_eligible = "dsr_eligible_"
+        prefix_dsr_montant = "dsr_montant_"
         df_results = simulate(request_body, prefix_dsr_eligible)
 
         # constuire la réponse
@@ -47,14 +48,14 @@ class Dotations(object):
             "amendement": {
                 "dotations": {
                     "communes": {
-                        "dsr": build_response_dsr("amendement", df_results, prefix_dsr_eligible)
+                        "dsr": build_response_dsr("amendement", df_results, prefix_dsr_eligible, prefix_dsr_montant)
                     }
                 }
             },
             "base": {
                 "dotations": {
                     "communes": {
-                        "dsr": build_response_dsr("base", df_results, prefix_dsr_eligible)
+                        "dsr": build_response_dsr("base", df_results, prefix_dsr_eligible, prefix_dsr_montant)
                     }
                 }
             }

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ impot_revenu_requirements = [
 ]
 
 dotations_requirements = [
-    "openfisca-france-dotations-locales >= 0.2.0, < 1.0.0",
+    "openfisca-france-dotations-locales >= 0.3.0, < 1.0.0",
 ]
 
 setup(

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -88,6 +88,26 @@ def print_eligible_comparison():
         print("Comparaison DGCL vs nous pour le calcul de", nom_ofdl)
         if data_sim[nom_ofdl].dtypes.name == 'bool':
             print(compare_results_bool(data_sim, nom_ofdl, nom_ofdl + "_precalc"))
+        else:
+            # On va printer de manière quelque peu désordonnées diverses métriques nous informant
+            # sur la précision de notre calcul
+            resultats_comparaison = compare_results_real(data_sim, nom_ofdl, nom_ofdl + "_precalc")
+            print("***Statistiques de base (variable à prédire)***")
+            print("Moyenne base", resultats_comparaison["Moyenne base"])
+            print("Ecart-type", resultats_comparaison["variance"] ** 0.5)
+            print("***Différence entre prédit et précalculé***")
+            for cle in ["L1", "L2", "L∞"]:
+                print(cle, ": ", resultats_comparaison[cle])
+            print("***Différence entre prédit et précalculé : répartition des écarts***")
+            for cle in ["min", "max"]:
+                print("ecart", cle, resultats_comparaison[cle])
+            print('***Différence entre prédit et précalculé : "identiques"***')
+            for cle in ["differents", "identiques"]:
+                print(cle, resultats_comparaison[cle])
+            print("***Répartition des écarts ordonnés par quantiles***")
+            for quantile_borne in resultats_comparaison["quantiles"]:
+                rang, valeur = resultats_comparaison["quantiles"][quantile_borne]
+                print("{}% (rang {})\t {:.2f}".format(int(quantile_borne * 100), rang, valeur))
 
 
 if __name__ == "__main__":

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -96,6 +96,8 @@ def print_eligible_comparison():
             print("***Statistiques de base (variable à prédire)***")
             print("Moyenne base", resultats_comparaison["Moyenne base"])
             print("Ecart-type", resultats_comparaison["variance"] ** 0.5)
+            print("***R² : pourcentage de la variance expliqué***")
+            print(f"{BLEU_CLAIR}", "{:.4f}%".format(resultats_comparaison["pourcentage expliqué"] * 100) , STOP_COULEUR, sep="")
             print("***Différence entre prédit et précalculé***")
             for cle in ["L1", "L2", "L∞"]:
                 print(cle, ": ", resultats_comparaison[cle])

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -24,10 +24,16 @@ tocompare = {"dsr_eligible_fraction_bourg_centre": elig_bc_dgcl,
              "dsr_eligible_fraction_cible": elig_cible_dgcl}
 
 
+# Columns to compare that contain a bool type
+# A pivot table will be printed that counts the number of values that have the different combination
+def compare_results_bool(data, nom_actual, nom_expected):
+    return data.pivot_table(code_comm, index=nom_actual, columns=nom_expected, aggfunc="count", fill_value=0)
+
+
 def check_variables_bool(data):
     res = {}
     for k, v in tocompare.items():
-        res[k] = data.pivot_table(code_comm, index=k, columns=v, aggfunc="count", fill_value=0)
+        res[k] = compare_results_bool(data, k, v)
     return res
 
 

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -82,7 +82,6 @@ def print_eligible_comparison():
     previous_length_data = len(data_sim)
     data_sim = data_sim.merge(data_calc_dgcl, how="inner", on=code_comm, suffixes=["", "_precalc"])
     assert(len(data_sim) == previous_length_data)
-    data_sim.to_csv("data_compare.csv")
 
     for nom_ofdl in colonnes_to_compute:
         print("Comparaison DGCL vs nous pour le calcul de", nom_ofdl)

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -37,6 +37,47 @@ def check_variables_bool(data):
     return res
 
 
+# Columns to compare that contain a number
+# There will be great output, e.g. :
+# Absolute differences : < 1 €, quantiles extrèmes, deciles de différence
+# Différence relative (osef un peu)
+# Erreur quadratique
+# Norme L1, L2,
+def compare_results_real(data, nom_actual, nom_expected):
+    res = {}
+    data_non_nul = data[(data[nom_actual] != 0) | data[nom_expected] != 0]
+    diff = sorted((data_non_nul[nom_actual] - data_non_nul[nom_expected]).tolist())
+    nb_non_nul = len(data_non_nul)
+    avg_size = sum(data_non_nul[nom_actual]) / nb_non_nul
+    avg_size2 = sum([i * i for i in data_non_nul[nom_actual]]) / (nb_non_nul - 1)
+    res["Moyenne base"] = avg_size
+    res["variance"] = avg_size2 - avg_size * avg_size
+
+    # Norme L1 : ecart absolu moyen
+    res["L1"] = sum([abs(dif) for dif in diff]) / nb_non_nul
+    # Norme L2 (norme euclidienne) : utile pour l'estimation
+    res["L2"] = (sum([dif * dif for dif in diff]) / nb_non_nul)**0.5
+    # Ah ben qu'est ce que je disais : la norme L2 permet de regarder
+    # quelle part de variance de la variable est expliquée par notre
+    # modèle
+    res["pourcentage expliqué"] = 1 - res["L2"]**2 / res["variance"]
+    # Différence maximale. Sert pas à grand chose.
+    res["L∞"] = max([abs(dif) for dif in diff])
+    quantiles = [0.01, 0.02, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.98, 0.99]
+    # Statistiques d'ordre sur les différences (min, max et quantiles)
+    res["min"] = min(diff)
+    res["max"] = max(diff)
+    res["quantiles"] = {}
+    for q in quantiles:
+        rang = int(q * (nb_non_nul - 1) + 0.5)
+        res["quantiles"][q] = (rang, diff[rang])
+    tolerance_difference = 1
+
+    # nombre de résultats considérés comme égaux (en fonction de la tolérance acceptable)
+    res["differents"] = len([d for d in diff if abs(d) > tolerance_difference])
+    res["identiques"] = nb_non_nul - res["differents"]
+    return res
+
 def print_eligible_comparison():
     PERIOD = "2020"
     DATA = adapt_dgcl_data(load_dgcl_file())

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -67,7 +67,7 @@ def print_eligible_comparison():
     PERIOD = "2020"
     data_dgcl = load_dgcl_file()
     data_calc_dgcl = get_dgcl_results(data_dgcl)
-    
+
     data_sim = adapt_dgcl_data(data_dgcl)
     TBS = CountryTaxBenefitSystem()
     sim = simulation_from_dgcl_csv(PERIOD, data_sim, TBS)

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -83,6 +83,8 @@ def print_eligible_comparison():
     data_sim = data_sim.merge(data_calc_dgcl, how="inner", on=code_comm, suffixes=["", "_precalc"])
     assert(len(data_sim) == previous_length_data)
 
+    summary_variables = {}  # récupère les R²
+
     BLEU_CLAIR = "\x1b[1;36;40m"
     STOP_COULEUR = "\033[0m"
     for nom_ofdl in colonnes_to_compute:
@@ -98,6 +100,7 @@ def print_eligible_comparison():
             print("Ecart-type", resultats_comparaison["variance"] ** 0.5)
             print("***R² : pourcentage de la variance expliqué***")
             print(f"{BLEU_CLAIR}", "{:.4f}%".format(resultats_comparaison["pourcentage expliqué"] * 100) , STOP_COULEUR, sep="")
+            summary_variables[nom_ofdl] = resultats_comparaison["pourcentage expliqué"] * 100
             print("***Différence entre prédit et précalculé***")
             for cle in ["L1", "L2", "L∞"]:
                 print(cle, ": ", resultats_comparaison[cle])
@@ -112,6 +115,15 @@ def print_eligible_comparison():
                 rang, valeur = resultats_comparaison["quantiles"][quantile_borne]
                 # le rang représente la quantité de communes concernées
                 print("{}% (rang {})\t {:.2f}".format(int(quantile_borne * 100), rang, valeur))
+    erreur_totale = 100 * len(summary_variables) - sum(summary_variables.values())
+    print(f"{BLEU_CLAIR}")
+    print("Résumé des pourcentages expliqués :")
+    largeur_justify_name = max([len(nom) for nom in summary_variables]) + 3
+    for variable, pourcentage_explique_variable in summary_variables.items():
+        print("{}{:>8.4f}".format(variable.ljust(largeur_justify_name, ' '), pourcentage_explique_variable))
+    print("Total des erreurs qui a peu de sens mathématique :")
+    print(erreur_totale)
+    print(STOP_COULEUR)
 
 
 if __name__ == "__main__":

--- a/tests/dotations/compare_with_dgcl.py
+++ b/tests/dotations/compare_with_dgcl.py
@@ -83,8 +83,10 @@ def print_eligible_comparison():
     data_sim = data_sim.merge(data_calc_dgcl, how="inner", on=code_comm, suffixes=["", "_precalc"])
     assert(len(data_sim) == previous_length_data)
 
+    BLEU_CLAIR = "\x1b[1;36;40m"
+    STOP_COULEUR = "\033[0m"
     for nom_ofdl in colonnes_to_compute:
-        print("Comparaison DGCL vs nous pour le calcul de", nom_ofdl)
+        print(f"{BLEU_CLAIR}Comparaison DGCL vs nous pour le calcul de", nom_ofdl, STOP_COULEUR)
         if data_sim[nom_ofdl].dtypes.name == 'bool':
             print(compare_results_bool(data_sim, nom_ofdl, nom_ofdl + "_precalc"))
         else:
@@ -103,13 +105,14 @@ def print_eligible_comparison():
             print('***Différence entre prédit et précalculé : "identiques"***')
             for cle in ["differents", "identiques"]:
                 print(cle, resultats_comparaison[cle])
-            print("***Répartition des écarts ordonnés par quantiles***")
+            print("***Répartition des écarts ordonnés par quantiles d'erreur***")
             for quantile_borne in resultats_comparaison["quantiles"]:
                 rang, valeur = resultats_comparaison["quantiles"][quantile_borne]
+                # le rang représente la quantité de communes concernées
                 print("{}% (rang {})\t {:.2f}".format(int(quantile_borne * 100), rang, valeur))
 
 
 if __name__ == "__main__":
     st = time()
     print_eligible_comparison()
-    print("Elapsed : {:.2f}".format(time() - st))
+    print("> Elapsed time: {:.2f}".format(time() - st))

--- a/tests/dotations/test_data.py
+++ b/tests/dotations/test_data.py
@@ -40,6 +40,11 @@ def table_openfisca_to_dgcl_column():
     return variables_openfisca_presentes_fichier
 
 
+def test_variables_bien_presentes(table_openfisca_to_dgcl_column, loaded_data):
+    for nom_dgcl_variable in table_openfisca_to_dgcl_column.values():
+        assert nom_dgcl_variable in loaded_data.columns
+
+
 def test_ajoute_population_plus_grande_commune_agglomeration(table_openfisca_to_dgcl_column):
     dgcl_pop_agglo = "Dotation de solidarité rurale Bourg-centre - Population DGF des communes de l'agglomération"
     dgcl_pop_dgf = "Informations générales - Population DGF Année N'"

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -110,11 +110,11 @@ def test_dsr_reform_popMax(client, headers):
 
     # Vérification des clefs du dictionnaire contenues dans un array :
     # cas-types
-    expected_cas_type_keys = set(["code", "eligible"])
+    expected_cas_type_keys = set(["code", "eligible", "dotationParHab"])
     for cas_type in base_dsr["communes"] + amendement_dsr["communes"]:
         assert set(cas_type.keys()) == expected_cas_type_keys
     # strates
-    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant"])
+    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsr["strates"] + amendement_dsr["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -84,8 +84,10 @@ def test_dsr_reform_popMax(client, headers):
     response = response_function(data=json.dumps(request))
     result = json.loads(response.data)
 
-    assert "base" in result
-    assert "amendement" in result
+    # Vérification des clefs du dictionnaire (sauf celles inclues dans un array)
+    flattened_result_keys = set(flattened_dict(result).keys())
+    flattened_expected_keys = set(flattened_dict(expected_reform_impact).keys())
+    assert flattened_result_keys == flattened_expected_keys
 
     base_dsr = result["base"]["dotations"]["communes"]["dsr"]
     amendement_dsr = result["amendement"]["dotations"]["communes"]["dsr"]
@@ -103,10 +105,6 @@ def test_dsr_reform_popMax(client, headers):
             == [description_strate["habitants"] for description_strate in amendement_dsr["strates"]]
             )
 
-    # Vérification des clefs du dictionnaire (sauf celles inclues dans un array)
-    flattened_result_keys = set(flattened_dict(result).keys())
-    flattened_expected_keys = set(flattened_dict(expected_reform_impact).keys())
-    assert flattened_result_keys == flattened_expected_keys
 
     # Vérification des clefs du dictionnaire contenues dans un array :
     # cas-types

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -244,4 +244,8 @@ def test_dsr_reform_popMax(client, headers):
         assert(distance_listes(expected_strates_part_pop, [strate["partPopTotale"] for strate in resultat_strates]) < allowed_error)
         assert(distance_listes(expected_strates_potentiel_financier, [strate["potentielFinancierMoyenParHabitant"] for strate in resultat_strates]) < allowed_error)
 
+    # Les nombres de communes éligibles de base sont ceux attendus
+    expected_strates_eligibilite_base = [17752, 11103, 3165, 1089, 55, 0, 0, 0]
+    assert expected_strates_eligibilite_base == [strate["eligibles"] for strate in base_dsr["strates"]]
+
     assert result == expected_reform_impact

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -58,69 +58,11 @@ def test_dsr_reform_popMax(client, headers):
             "dotations": {
                 "communes": {
                     "dsr": {
-                        "communes": [
-                            {
-                                "code": "76384",
-                                "eligible": False
-                            },
-                            {
-                                "code": "76214",
-                                "eligible": True
-                            }
-                        ],
+                        "communes": [],
                         "eligibles": 17049,
                         "nouvellementEligibles": 0,
                         "plusEligibles": 16115,
-                        "strates": [
-                            {
-                                "eligibles": 16924,
-                                "habitants": 0,
-                                "partPopTotale": 0.0603242951533041,
-                                "potentielFinancierMoyenParHabitant": 761.7826724474608
-                            },
-                            {
-                                "eligibles": 1,
-                                "habitants": 500,
-                                "partPopTotale": 0.16357006593471596,
-                                "potentielFinancierMoyenParHabitant": 822.7862081792102
-                            },
-                            {
-                                "eligibles": 27,
-                                "habitants": 2000,
-                                "partPopTotale": 0.1481666253006925,
-                                "potentielFinancierMoyenParHabitant": 962.3232471567082
-                            },
-                            {
-                                "eligibles": 47,
-                                "habitants": 5000,
-                                "partPopTotale": 0.12193926697939683,
-                                "potentielFinancierMoyenParHabitant": 1061.3215646634023
-                            },
-                            {
-                                "eligibles": 50,
-                                "habitants": 10000,
-                                "partPopTotale": 0.11254269030454657,
-                                "potentielFinancierMoyenParHabitant": 1142.2386532655016
-                            },
-                            {
-                                "eligibles": 0,
-                                "habitants": 20000,
-                                "partPopTotale": 0.15472973351983596,
-                                "potentielFinancierMoyenParHabitant": 1212.5588966550042
-                            },
-                            {
-                                "eligibles": 0,
-                                "habitants": 50000,
-                                "partPopTotale": 0.08756806900354432,
-                                "potentielFinancierMoyenParHabitant": 1322.006448304583
-                            },
-                            {
-                                "eligibles": 0,
-                                "habitants": 100000,
-                                "partPopTotale": 0.15115925380396375,
-                                "potentielFinancierMoyenParHabitant": 1450.6968113217495
-                            }
-                        ]
+                        "strates": []
                     }
                 }
             }
@@ -129,67 +71,9 @@ def test_dsr_reform_popMax(client, headers):
             "dotations": {
                 "communes": {
                     "dsr": {
-                        "communes": [
-                            {
-                                "code": "76384",
-                                "eligible": False
-                            },
-                            {
-                                "code": "76214",
-                                "eligible": True
-                            }
-                        ],
+                        "communes": [],
                         "eligibles": 33164,
-                        "strates": [
-                            {
-                                "eligibles": 17752,
-                                "habitants": 0,
-                                "partPopTotale": 0.0603242951533041,
-                                "potentielFinancierMoyenParHabitant": 761.7826724474608
-                            },
-                            {
-                                "eligibles": 11103,
-                                "habitants": 500,
-                                "partPopTotale": 0.16357006593471596,
-                                "potentielFinancierMoyenParHabitant": 822.7862081792102
-                            },
-                            {
-                                "eligibles": 3165,
-                                "habitants": 2000,
-                                "partPopTotale": 0.1481666253006925,
-                                "potentielFinancierMoyenParHabitant": 962.3232471567082
-                            },
-                            {
-                                "eligibles": 1089,
-                                "habitants": 5000,
-                                "partPopTotale": 0.12193926697939683,
-                                "potentielFinancierMoyenParHabitant": 1061.3215646634023
-                            },
-                            {
-                                "eligibles": 55,
-                                "habitants": 10000,
-                                "partPopTotale": 0.11254269030454657,
-                                "potentielFinancierMoyenParHabitant": 1142.2386532655016
-                            },
-                            {
-                                "eligibles": 0,
-                                "habitants": 20000,
-                                "partPopTotale": 0.15472973351983596,
-                                "potentielFinancierMoyenParHabitant": 1212.5588966550042
-                            },
-                            {
-                                "eligibles": 0,
-                                "habitants": 50000,
-                                "partPopTotale": 0.08756806900354432,
-                                "potentielFinancierMoyenParHabitant": 1322.006448304583
-                            },
-                            {
-                                "eligibles": 0,
-                                "habitants": 100000,
-                                "partPopTotale": 0.15115925380396375,
-                                "potentielFinancierMoyenParHabitant": 1450.6968113217495
-                            }
-                        ]
+                        "strates": []
                     }
                 }
             }
@@ -255,5 +139,3 @@ def test_dsr_reform_popMax(client, headers):
 
     # Les deux cas types ont une éligibilité différente avec la loi actuelle (sinon on s'ennuye)
     assert (len(set([cas_type["eligible"] for cas_type in base_dsr["communes"]])) > 1)
-
-    assert result == expected_reform_impact

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -1,7 +1,7 @@
 from functools import partial
 import json
 
-from dotations.impact import BORNES_STRATES  # type: ignore
+from dotations.impact import BORNES_STRATES, get_cas_types_codes_insee  # type: ignore
 
 
 def test_dotations_request_body_error(client, headers):
@@ -201,7 +201,12 @@ def test_dsr_reform_popMax(client, headers):
     base_dsr = result["base"]["dotations"]["communes"]["dsr"]
     amendement_dsr = result["amendement"]["dotations"]["communes"]["dsr"]
     # même nombre de cas types en loi actuelle et amendement
-    assert len(base_dsr["communes"]) == len(amendement_dsr["communes"])
+    # Les cas_types sont ceux attendus
+    codes_communes = get_cas_types_codes_insee()
+    assert (codes_communes
+            == [cas_type["code"] for cas_type in base_dsr["communes"]]
+            == [cas_type["code"] for cas_type in amendement_dsr["communes"]]
+            )
 
     assert (len(BORNES_STRATES) - 1) == len(base_dsr["strates"]) == len(amendement_dsr["strates"])
     assert (BORNES_STRATES[:-1]

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -140,7 +140,6 @@ def test_dsr_reform_popMax(client, headers):
     # Les deux cas types ont une éligibilité différente avec la loi actuelle (sinon on s'ennuye)
     assert (len(set([cas_type["eligible"] for cas_type in base_dsr["communes"]])) > 1)
 
-
     # Montants : cohérence : les cas_types ont une dotation non nulle si et seulement si elles sont éligibles
     for scenario_cas_types in [base_dsr["communes"], amendement_dsr["communes"]]:
         for cas_type in scenario_cas_types:

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -5,6 +5,10 @@ from dotations.impact import BORNES_STRATES, get_cas_types_codes_insee  # type: 
 from dotations.utils_dict import flattened_dict  # type: ignore
 
 
+def distance_listes(a, b):
+    return max([abs(x - y) for (x, y) in zip(a, b)])
+
+
 def test_dotations_request_body_error(client, headers):
     request = {}
 
@@ -229,5 +233,15 @@ def test_dsr_reform_popMax(client, headers):
     expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant"])
     for strate in base_dsr["strates"] + amendement_dsr["strates"]:
         assert set(strate.keys()) == expected_strates_keys
+
+    # Vérification des valeurs connues :
+    # part des populations des strates
+
+    expected_strates_part_pop = [0.060324, 0.16357, 0.14816, 0.12193, 0.112542, 0.15472, 0.087568, 0.151159]
+    expected_strates_potentiel_financier = [761.7826724474608, 822.7862081792102, 962.3232471567082, 1061.3215646634023, 1142.2386532655016, 1212.5588966550042, 1322.006448304583, 1450.6968113217495]
+    allowed_error = 0.0001
+    for resultat_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
+        assert(distance_listes(expected_strates_part_pop, [strate["partPopTotale"] for strate in resultat_strates]) < allowed_error)
+        assert(distance_listes(expected_strates_potentiel_financier, [strate["potentielFinancierMoyenParHabitant"] for strate in resultat_strates]) < allowed_error)
 
     assert result == expected_reform_impact

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -5,7 +5,7 @@ from dotations.impact import BORNES_STRATES, get_cas_types_codes_insee  # type: 
 from dotations.utils_dict import flattened_dict  # type: ignore
 
 
-def distance_listes(a, b):
+def _distance_listes(a, b):
     return max([abs(x - y) for (x, y) in zip(a, b)])
 
 
@@ -35,7 +35,7 @@ def test_dotations(client, headers):
     assert response.status_code == 200
 
 
-def test_dsr_reform_popMax(client, headers):
+def test_dsr_reform_eligibilite_montants(client, headers):
     request = {
         "reforme": {
             "dotations": {
@@ -91,40 +91,8 @@ def test_dsr_reform_popMax(client, headers):
 
     base_dsr = result["base"]["dotations"]["communes"]["dsr"]
     amendement_dsr = result["amendement"]["dotations"]["communes"]["dsr"]
-    # même nombre de cas types en loi actuelle et amendement
-    # Les cas_types sont ceux attendus
-    codes_communes = get_cas_types_codes_insee()
-    assert (codes_communes
-            == [cas_type["code"] for cas_type in base_dsr["communes"]]
-            == [cas_type["code"] for cas_type in amendement_dsr["communes"]]
-            )
-
-    assert (len(BORNES_STRATES) - 1) == len(base_dsr["strates"]) == len(amendement_dsr["strates"])
-    assert (BORNES_STRATES[:-1]
-            == [description_strate["habitants"] for description_strate in base_dsr["strates"]]
-            == [description_strate["habitants"] for description_strate in amendement_dsr["strates"]]
-            )
-
-
-    # Vérification des clefs du dictionnaire contenues dans un array :
-    # cas-types
-    expected_cas_type_keys = set(["code", "eligible", "dotationParHab"])
-    for cas_type in base_dsr["communes"] + amendement_dsr["communes"]:
-        assert set(cas_type.keys()) == expected_cas_type_keys
-    # strates
-    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
-    for strate in base_dsr["strates"] + amendement_dsr["strates"]:
-        assert set(strate.keys()) == expected_strates_keys
 
     # Vérification des valeurs connues :
-    # part des populations des strates
-
-    expected_strates_part_pop = [0.060324, 0.16357, 0.14816, 0.12193, 0.112542, 0.15472, 0.087568, 0.151159]
-    expected_strates_potentiel_financier = [761.7826724474608, 822.7862081792102, 962.3232471567082, 1061.3215646634023, 1142.2386532655016, 1212.5588966550042, 1322.006448304583, 1450.6968113217495]
-    allowed_error = 0.0001
-    for resultat_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
-        assert(distance_listes(expected_strates_part_pop, [strate["partPopTotale"] for strate in resultat_strates]) < allowed_error)
-        assert(distance_listes(expected_strates_potentiel_financier, [strate["potentielFinancierMoyenParHabitant"] for strate in resultat_strates]) < allowed_error)
 
     # Les nombres de communes éligibles de base sont ceux attendus
     expected_strates_eligibilite_base = [17752, 11103, 3165, 1089, 55, 0, 0, 0]
@@ -146,3 +114,154 @@ def test_dsr_reform_popMax(client, headers):
     for scenario_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
         for strate in scenario_strates:
             assert((strate["dotationMoyenneParHab"] > 0) == (strate["eligibles"] > 0))
+
+
+def test_dsr_reform_cas_types(client, headers):
+    request = {
+        "reforme": {
+            "dotations": {
+                "montants": {
+                    "dgf": 31
+                },
+                "communes": {
+                    "dsr": {
+                        "eligibilite": {
+                            "popMax": 500  # de 10 000 à 500
+                        }
+                    }
+                }
+            }
+        }
+    }
+    # avant réforme : +11 000 communes éligibles à la DSR (toutes fractions comprises)
+    expected_reform_impact = {
+        "amendement": {
+            "dotations": {
+                "communes": {
+                    "dsr": {
+                        "communes": [],
+                        "eligibles": 17049,
+                        "nouvellementEligibles": 0,
+                        "plusEligibles": 16115,
+                        "strates": []
+                    }
+                }
+            }
+        },
+        "base": {
+            "dotations": {
+                "communes": {
+                    "dsr": {
+                        "communes": [],
+                        "eligibles": 33164,
+                        "strates": []
+                    }
+                }
+            }
+        }
+    }
+
+    response_function = partial(client.post, "dotations", headers=headers)
+    response = response_function(data=json.dumps(request))
+    result = json.loads(response.data)
+
+    # Vérification des clefs du dictionnaire (sauf celles inclues dans un array)
+    flattened_result_keys = set(flattened_dict(result).keys())
+    flattened_expected_keys = set(flattened_dict(expected_reform_impact).keys())
+    assert flattened_result_keys == flattened_expected_keys
+
+    base_dsr = result["base"]["dotations"]["communes"]["dsr"]
+    amendement_dsr = result["amendement"]["dotations"]["communes"]["dsr"]
+
+    # même nombre de cas types en loi actuelle et amendement
+    # Les cas_types sont ceux attendus
+    codes_communes = get_cas_types_codes_insee()
+    assert (codes_communes
+            == [cas_type["code"] for cas_type in base_dsr["communes"]]
+            == [cas_type["code"] for cas_type in amendement_dsr["communes"]]
+            )
+
+    # Vérification des clefs du dictionnaire contenues dans un array :
+    # cas-types
+    expected_cas_type_keys = set(["code", "eligible", "dotationParHab"])
+    for cas_type in base_dsr["communes"] + amendement_dsr["communes"]:
+        assert set(cas_type.keys()) == expected_cas_type_keys
+
+
+def test_dsr_reform_strates(client, headers):
+    request = {
+        "reforme": {
+            "dotations": {
+                "montants": {
+                    "dgf": 31
+                },
+                "communes": {
+                    "dsr": {
+                        "eligibilite": {
+                            "popMax": 500  # de 10 000 à 500
+                        }
+                    }
+                }
+            }
+        }
+    }
+    # avant réforme : +11 000 communes éligibles à la DSR (toutes fractions comprises)
+    expected_reform_impact = {
+        "amendement": {
+            "dotations": {
+                "communes": {
+                    "dsr": {
+                        "communes": [],
+                        "eligibles": 17049,
+                        "nouvellementEligibles": 0,
+                        "plusEligibles": 16115,
+                        "strates": []
+                    }
+                }
+            }
+        },
+        "base": {
+            "dotations": {
+                "communes": {
+                    "dsr": {
+                        "communes": [],
+                        "eligibles": 33164,
+                        "strates": []
+                    }
+                }
+            }
+        }
+    }
+
+    response_function = partial(client.post, "dotations", headers=headers)
+    response = response_function(data=json.dumps(request))
+    result = json.loads(response.data)
+
+    # Vérification des clefs du dictionnaire (sauf celles inclues dans un array)
+    flattened_result_keys = set(flattened_dict(result).keys())
+    flattened_expected_keys = set(flattened_dict(expected_reform_impact).keys())
+    assert flattened_result_keys == flattened_expected_keys
+
+    base_dsr = result["base"]["dotations"]["communes"]["dsr"]
+    amendement_dsr = result["amendement"]["dotations"]["communes"]["dsr"]
+
+    assert (len(BORNES_STRATES) - 1) == len(base_dsr["strates"]) == len(amendement_dsr["strates"])
+    assert (BORNES_STRATES[:-1]
+            == [description_strate["habitants"] for description_strate in base_dsr["strates"]]
+            == [description_strate["habitants"] for description_strate in amendement_dsr["strates"]]
+            )
+
+    # Vérification des clefs du dictionnaire contenues dans un array :
+    # strates
+    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    for strate in base_dsr["strates"] + amendement_dsr["strates"]:
+        assert set(strate.keys()) == expected_strates_keys
+
+    # Vérification des valeurs connues :
+    # part des populations des strates
+    expected_strates_part_pop = [0.060324, 0.16357, 0.14816, 0.12193, 0.112542, 0.15472, 0.087568, 0.151159]
+    expected_strates_potentiel_financier = [761.7826724474608, 822.7862081792102, 962.3232471567082, 1061.3215646634023, 1142.2386532655016, 1212.5588966550042, 1322.006448304583, 1450.6968113217495]
+    allowed_error = 0.0001
+    for resultat_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
+        assert(_distance_listes(expected_strates_part_pop, [strate["partPopTotale"] for strate in resultat_strates]) < allowed_error)
+        assert(_distance_listes(expected_strates_potentiel_financier, [strate["potentielFinancierMoyenParHabitant"] for strate in resultat_strates]) < allowed_error)

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -248,4 +248,12 @@ def test_dsr_reform_popMax(client, headers):
     expected_strates_eligibilite_base = [17752, 11103, 3165, 1089, 55, 0, 0, 0]
     assert expected_strates_eligibilite_base == [strate["eligibles"] for strate in base_dsr["strates"]]
 
+    # Moins de communes éligibles après que avant.
+    assert (base_dsr["eligibles"] > amendement_dsr["eligibles"])
+    # Les nombres affichés dans l'amendement sont cohérents avec la base
+    assert(base_dsr["eligibles"] == amendement_dsr["eligibles"] - amendement_dsr["nouvellementEligibles"] + amendement_dsr["plusEligibles"])
+
+    # Les deux cas types ont une éligibilité différente avec la loi actuelle (sinon on s'ennuye)
+    assert (len(set([cas_type["eligible"] for cas_type in base_dsr["communes"]])) > 1)
+
     assert result == expected_reform_impact

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -2,6 +2,7 @@ from functools import partial
 import json
 
 from dotations.impact import BORNES_STRATES, get_cas_types_codes_insee  # type: ignore
+from dotations.utils_dict import flattened_dict  # type: ignore
 
 
 def test_dotations_request_body_error(client, headers):
@@ -213,5 +214,10 @@ def test_dsr_reform_popMax(client, headers):
             == [description_strate["habitants"] for description_strate in base_dsr["strates"]]
             == [description_strate["habitants"] for description_strate in amendement_dsr["strates"]]
             )
+
+    # Vérification des clefs du dictionnaire (sauf celles inclues dans un array)
+    flattened_result_keys = set(flattened_dict(result).keys())
+    flattened_expected_keys = set(flattened_dict(expected_reform_impact).keys())
+    assert flattened_result_keys == flattened_expected_keys
 
     assert result == expected_reform_impact

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -220,4 +220,14 @@ def test_dsr_reform_popMax(client, headers):
     flattened_expected_keys = set(flattened_dict(expected_reform_impact).keys())
     assert flattened_result_keys == flattened_expected_keys
 
+    # Vérification des clefs du dictionnaire contenues dans un array :
+    # cas-types
+    expected_cas_type_keys = set(["code", "eligible"])
+    for cas_type in base_dsr["communes"] + amendement_dsr["communes"]:
+        assert set(cas_type.keys()) == expected_cas_type_keys
+    # strates
+    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant"])
+    for strate in base_dsr["strates"] + amendement_dsr["strates"]:
+        assert set(strate.keys()) == expected_strates_keys
+
     assert result == expected_reform_impact

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -139,3 +139,13 @@ def test_dsr_reform_popMax(client, headers):
 
     # Les deux cas types ont une éligibilité différente avec la loi actuelle (sinon on s'ennuye)
     assert (len(set([cas_type["eligible"] for cas_type in base_dsr["communes"]])) > 1)
+
+
+    # Montants : cohérence : les cas_types ont une dotation non nulle si et seulement si elles sont éligibles
+    for scenario_cas_types in [base_dsr["communes"], amendement_dsr["communes"]]:
+        for cas_type in scenario_cas_types:
+            assert((cas_type["dotationParHab"] > 0) == cas_type["eligible"])
+    # Montants : cohérence : les strates ont une dotation non nulle si et seulement si elles sont éligibles
+    for scenario_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
+        for strate in scenario_strates:
+            assert((strate["dotationMoyenneParHab"] > 0) == (strate["eligibles"] > 0))


### PR DESCRIPTION
La nouvelle PR à la mode !!!

Elle inclut trois parties : 

- Une qui consiste à redesigner un peu les tests dotations, pour qu'ils soient plus fonctionnels, mais aussi pour pouvoir supprimer le check d'égalité parfaite de 2 dictionnaires complexes qui rendrait relou tout changement dans le futur : j'ai tenté de traduire les vraies choses qu'on essaye de checker, puis je retire le test d'égalité des dictionnaires. On peut en parler si tu veux qu'on aille plus avant sur les vrais tests mais je pense qu'on couvre déjà bien.

- A partir du commit "Bumps required OFDL version", on plonge dans le monde onirique du calcul des montants **hors garanties** de la DSR. ses trois fractions n'auront plus de secret pour vous (enfin si, vu que c'est OFDL qui fait tout le boulot sous le capot). Attention, utilise une version d'OFDL pour les connaisseurs, qui n'est pas encore sortie (mais dont on subodore qu'elle sera la version 0.3.0)

- A partir du commit "Adds a function that extracts precomputed results from DGCL", refactore la fonction qui compare avec la DGCL et compare désormais des colonnes numériques

Elle est prête à être reviewed, mais elle vient bien sûr après celle d'OFDL.

En supposant qu'on merge la PR22 en l'état, je reporte ici les éléments de la todolitre restant : 

- [x] implémenter les montants 
- [ ] optimisation du temps de calcul (par exemple par du preload)
- [ ] fonction de recherche / des villes
- [ ] lots of documentation
- [ ] lots of additional tests
- [ ] lots of typing

