### PR TITLE
Pourcentage eligible

### DIFF
--- a/dotations/impact.py
+++ b/dotations/impact.py
@@ -88,6 +88,7 @@ def build_response_dotations_strates(scenario, df_results, prefix_eligible, pref
         res_strates[id_borne]["potentielFinancierMoyenParHabitant"] = pot_strate / pop_strate
         nb_elig_strate = resultats_agreges_bornes[id_borne]["eligibles"] - resultats_agreges_bornes[id_borne + 1]["eligibles"]
         nombre_communes_strate = resultats_agreges_bornes[id_borne]["nombre_communes"] - resultats_agreges_bornes[id_borne + 1]["nombre_communes"]
+        res_strates[id_borne]["eligibles"] = nb_elig_strate
         res_strates[id_borne]["proportionEligibles"] = (nb_elig_strate / nombre_communes_strate) if nombre_communes_strate else 0
         res_strates[id_borne]["dotationMoyenneParHab"] = max(0, resultats_agreges_bornes[id_borne]["montant"] - resultats_agreges_bornes[id_borne + 1]["montant"]) / pop_strate
         res_strates[id_borne]["partDotationTotale"] = (

--- a/dotations/impact.py
+++ b/dotations/impact.py
@@ -77,6 +77,7 @@ def build_response_dotations_strates(scenario, df_results, prefix_eligible, pref
         resultats_agreges_bornes[id_borne]["potentiel_financier"] = float(df_strate["potentiel_financier" + "_" + scenario].sum())
         resultats_agreges_bornes[id_borne]["eligibles"] = int(df_strate[prefix_eligible + scenario].sum())
         resultats_agreges_bornes[id_borne]["montant"] = int(df_strate[prefix_montant + scenario].sum())
+        resultats_agreges_bornes[id_borne]["nombre_communes"] = len(df_strate)
 
     res_strates: List[dict] = [{} for borne in BORNES_STRATES[:-1]]
     for id_borne in range(len(BORNES_STRATES) - 1):
@@ -86,7 +87,8 @@ def build_response_dotations_strates(scenario, df_results, prefix_eligible, pref
         pot_strate = resultats_agreges_bornes[id_borne]["potentiel_financier"] - resultats_agreges_bornes[id_borne + 1]["potentiel_financier"]
         res_strates[id_borne]["potentielFinancierMoyenParHabitant"] = pot_strate / pop_strate
         nb_elig_strate = resultats_agreges_bornes[id_borne]["eligibles"] - resultats_agreges_bornes[id_borne + 1]["eligibles"]
-        res_strates[id_borne]["eligibles"] = nb_elig_strate
+        nombre_communes_strate = resultats_agreges_bornes[id_borne]["nombre_communes"] - resultats_agreges_bornes[id_borne + 1]["nombre_communes"]
+        res_strates[id_borne]["proportionEligibles"] = (nb_elig_strate / nombre_communes_strate) if nombre_communes_strate else 0
         res_strates[id_borne]["dotationMoyenneParHab"] = max(0, resultats_agreges_bornes[id_borne]["montant"] - resultats_agreges_bornes[id_borne + 1]["montant"]) / pop_strate
         res_strates[id_borne]["partDotationTotale"] = (
             (resultats_agreges_bornes[id_borne]["montant"] - resultats_agreges_bornes[id_borne + 1]["montant"]) / resultats_agreges_bornes[0]["montant"]

--- a/dotations/impact.py
+++ b/dotations/impact.py
@@ -89,7 +89,7 @@ def build_response_dotations_strates(scenario, df_results, prefix_eligible, pref
         nb_elig_strate = resultats_agreges_bornes[id_borne]["eligibles"] - resultats_agreges_bornes[id_borne + 1]["eligibles"]
         nombre_communes_strate = resultats_agreges_bornes[id_borne]["nombre_communes"] - resultats_agreges_bornes[id_borne + 1]["nombre_communes"]
         res_strates[id_borne]["eligibles"] = nb_elig_strate
-        res_strates[id_borne]["proportionEligibles"] = (nb_elig_strate / nombre_communes_strate) if nombre_communes_strate else 0
+        res_strates[id_borne]["partEligibles"] = (nb_elig_strate / nombre_communes_strate) if nombre_communes_strate else 0
         res_strates[id_borne]["dotationMoyenneParHab"] = max(0, resultats_agreges_bornes[id_borne]["montant"] - resultats_agreges_bornes[id_borne + 1]["montant"]) / pop_strate
         res_strates[id_borne]["partDotationTotale"] = (
             (resultats_agreges_bornes[id_borne]["montant"] - resultats_agreges_bornes[id_borne + 1]["montant"]) / resultats_agreges_bornes[0]["montant"]

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -167,6 +167,11 @@ def test_dsr_reform_eligibilite_montants(response_dotations):
     base_dsr = result["base"]["communes"]["dsr"]
     amendement_dsr = result["amendement"]["communes"]["dsr"]
 
+    # Vérification des valeurs connues :
+    # Les nombres de communes éligibles de base sont ceux attendus
+    expected_strates_eligibilite_base = [17752, 11103, 3165, 1089, 55, 0, 0, 0]
+    assert expected_strates_eligibilite_base == [strate["eligibles"] for strate in base_dsr["strates"]]
+
     # Moins de communes éligibles après que avant.
     assert (base_dsr["eligibles"] > amendement_dsr["eligibles"])
     # Les nombres affichés dans l'amendement sont cohérents avec la base
@@ -177,6 +182,7 @@ def test_dsr_reform_eligibilite_montants(response_dotations):
     # Montants : cohérence : les strates ont une dotation non nulle si et seulement si elles sont éligibles
     for scenario_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
         for strate in scenario_strates:
+            assert((strate["dotationMoyenneParHab"] > 0) == (strate["eligibles"] > 0))
             assert((strate["dotationMoyenneParHab"] > 0) == (strate["proportionEligibles"] > 0))
 
 
@@ -219,7 +225,7 @@ def test_dsr_reform_strates(response_dotations):
             )
     # Vérification des clefs du dictionnaire contenues dans un array :
     # strates
-    expected_strates_keys = set(["proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    expected_strates_keys = set(["eligibles", "proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsr["strates"] + amendement_dsr["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 
@@ -245,7 +251,7 @@ def test_dsu_reform_strates(response_dotations):
             )
     # Vérification des clefs du dictionnaire contenues dans un array :
     # strates
-    expected_strates_keys = set(["proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    expected_strates_keys = set(["eligibles", "proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsu["strates"] + amendement_dsu["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -177,7 +177,7 @@ def test_dsr_reform_eligibilite_montants(response_dotations):
     # Montants : cohérence : les strates ont une dotation non nulle si et seulement si elles sont éligibles
     for scenario_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
         for strate in scenario_strates:
-            assert((strate["dotationMoyenneParHab"] > 0) == (strate["eligibles"] > 0))
+            assert((strate["dotationMoyenneParHab"] > 0) == (strate["proportionEligibles"] > 0))
 
 
 def test_dsr_reform_cas_types(response_dotations, codes_communes_examples):
@@ -219,7 +219,7 @@ def test_dsr_reform_strates(response_dotations):
             )
     # Vérification des clefs du dictionnaire contenues dans un array :
     # strates
-    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    expected_strates_keys = set(["proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsr["strates"] + amendement_dsr["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 
@@ -245,7 +245,7 @@ def test_dsu_reform_strates(response_dotations):
             )
     # Vérification des clefs du dictionnaire contenues dans un array :
     # strates
-    expected_strates_keys = set(["eligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    expected_strates_keys = set(["proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsu["strates"] + amendement_dsu["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -183,7 +183,7 @@ def test_dsr_reform_eligibilite_montants(response_dotations):
     for scenario_strates in [base_dsr["strates"], amendement_dsr["strates"]]:
         for strate in scenario_strates:
             assert((strate["dotationMoyenneParHab"] > 0) == (strate["eligibles"] > 0))
-            assert((strate["dotationMoyenneParHab"] > 0) == (strate["proportionEligibles"] > 0))
+            assert((strate["dotationMoyenneParHab"] > 0) == (strate["partEligibles"] > 0))
 
 
 def test_dsr_reform_cas_types(response_dotations, codes_communes_examples):
@@ -225,7 +225,7 @@ def test_dsr_reform_strates(response_dotations):
             )
     # Vérification des clefs du dictionnaire contenues dans un array :
     # strates
-    expected_strates_keys = set(["eligibles", "proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    expected_strates_keys = set(["eligibles", "partEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsr["strates"] + amendement_dsr["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 
@@ -251,7 +251,7 @@ def test_dsu_reform_strates(response_dotations):
             )
     # Vérification des clefs du dictionnaire contenues dans un array :
     # strates
-    expected_strates_keys = set(["eligibles", "proportionEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
+    expected_strates_keys = set(["eligibles", "partEligibles", "habitants", "partPopTotale", "potentielFinancierMoyenParHabitant", "dotationMoyenneParHab", "partDotationTotale"])
     for strate in base_dsu["strates"] + amendement_dsu["strates"]:
         assert set(strate.keys()) == expected_strates_keys
 

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -167,11 +167,6 @@ def test_dsr_reform_eligibilite_montants(response_dotations):
     base_dsr = result["base"]["communes"]["dsr"]
     amendement_dsr = result["amendement"]["communes"]["dsr"]
 
-    # Vérification des valeurs connues :
-    # Les nombres de communes éligibles de base sont ceux attendus
-    expected_strates_eligibilite_base = [17752, 11103, 3165, 1089, 55, 0, 0, 0]
-    assert expected_strates_eligibilite_base == [strate["eligibles"] for strate in base_dsr["strates"]]
-
     # Moins de communes éligibles après que avant.
     assert (base_dsr["eligibles"] > amendement_dsr["eligibles"])
     # Les nombres affichés dans l'amendement sont cohérents avec la base


### PR DESCRIPTION
cf carte Trello https://trello.com/c/124jhoWk/372-tableau-mettre-le-pourcentage-de-communes-%C3%A9ligibles-et-non-le-nombre

Cette PR ajoute dans la partie "strates" de l'output l'élément "~proportion~partEligibles", qui décrit la proportion de communes de la strate éligibles à la DSR et la DSU
