### PR TITLE
Active le PLF pour les dotations

### DIFF
--- a/server/handlers/dotations.py
+++ b/server/handlers/dotations.py
@@ -1,7 +1,7 @@
 from http.client import OK, BAD_REQUEST
 
 from dotations.impact import build_response_dotations, build_response_dotations_eligibilites_changements  # type: ignore
-from Simulation_engine.simulate_dotations import simulate
+from Simulation_engine.simulate_dotations import simulate, ACTIVATE_PLF
 from typing import List
 
 # Checks whether all dictionnaries in the model exist in the target dict.
@@ -101,5 +101,20 @@ class Dotations(object):
                 }
             }
         }
+
+        if ACTIVATE_PLF:
+            simulation_result["plf"] = {
+                "communes": {
+                    "dsr": build_response_dotations("plf", df_results, prefix_dsr_eligible, prefix_dsr_montant, communes_cas_types=communes_cas_types, strates=strates, prefix_annees_convergence=prefix_annees_convergence, prefix_next_year=prefix_dsr_next_year),
+                    "dsu": build_response_dotations("plf", df_results, "dsu_eligible_", "dsu_montant_", communes_cas_types=communes_cas_types, strates=strates),
+                }
+            }
+
+            simulation_result["baseToPlf"] = {
+                "communes": {
+                    "dsr": build_response_dotations_eligibilites_changements("plf", df_results, prefix_dsr_eligible),
+                    "dsu": build_response_dotations_eligibilites_changements("plf", df_results, "dsu_eligible_")
+                }
+            }
 
         return simulation_result, OK

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -3,6 +3,7 @@ import json
 from pytest import fixture
 
 from dotations.impact import BORNES_STRATES_DEFAULT, get_cas_types_codes_insee  # type: ignore
+from Simulation_engine.simulate_dotations import ACTIVATE_PLF  # type: ignore
 from utils.utils_dict import flattened_dict  # type: ignore
 
 
@@ -153,6 +154,36 @@ def test_fields_response(response_dotations):
             }
         }
     }
+
+    if ACTIVATE_PLF:
+        expected_response_structure["plf"] = {
+            "communes": {
+                "dsr": {
+                    "communes": [],
+                    "eligibles": 33159,
+                    "strates": []
+                },
+                "dsu": {
+                    "communes": [],
+                    "eligibles": 818,
+                    "strates": []
+                }
+            }
+        }
+        expected_response_structure["baseToPlf"] = {
+            "communes": {
+                "dsr" : {
+                    "nouvellementEligibles": 0,
+                    "plusEligibles": 0,
+                    "toujoursEligibles": 33159,
+                },
+                "dsu" : {
+                    "nouvellementEligibles": 0,
+                    "plusEligibles": 0,
+                    "toujoursEligibles": 818,
+                }
+            }
+        }
 
     result = response_dotations
 


### PR DESCRIPTION
Connected to leximpact/leximpact-client#103

Active le PLF pour la DSR et la DSU.
Définit les valeurs de PLF au PLF 2021 qui : 
* ne modifie pas le mécanisme d'éligibilité
* accroît le montant de la DSR et la DSU de 90 millions d'euros chacune.

L'endpoint `/dotations` renvoie désormais une réponse enrichie à sa racine des clefs `plf` et `baseToPlf`.

Exemple de contenu pour les nouvelles clefs : 
```json
{
   "baseToPlf": {
        "communes": {
            "dsr": {
                "nouvellementEligibles": 0,
                "plusEligibles": 0,
                "toujoursEligibles": 33159
            },
            "dsu": {
                "nouvellementEligibles": 0,
                "plusEligibles": 0,
                "toujoursEligibles": 818
            }
        }
    },
    "plf": {
        "communes": {
            "dsr": {
                "communes": [...],
                "eligibles": 33159,
                "strates": [...]
             },
             "dsu": {
                "communes": [...],
                "eligibles": 818,
                "strates": [...]
             }
        }
    }
}
```
