### PR TITLE
Amélioration de la DSR : montant année prochaine et durée avant terme

### DIFF
--- a/Simulation_engine/simulate_dotations.py
+++ b/Simulation_engine/simulate_dotations.py
@@ -89,7 +89,8 @@ def simulate(request_body, prefix_dsr_eligible, prefix_dsr_montant, prefix_dsr_m
     variables_aggregations = ["potentiel_financier"]
     fractions_dsr = ["bourg_centre", "perequation", "cible"]
     variables_montants_fractions_dsr = ["dsr_montant_hors_garanties_fraction_" + nom_fraction for nom_fraction in fractions_dsr]
-    variables_montants_next_year_dsr = ["dsr_montant_eligible_fraction_bourg_centre", "dsr_montant_eligible_fraction_perequation"]
+    # Utilisées pour le calcul des effets tunnels de la DSR.
+    variables_montants_next_year_dsr = ["dsr_montant_eligible_fraction_bourg_centre", "dsr_montant_eligible_fraction_perequation", "dsr_montant_garantie_non_eligible_fraction_bourg_centre", "dsr_montant_garantie_non_eligible_fraction_cible"]
 
     to_compute = (
         variables_nombre_communes

--- a/dotations/simulation.py
+++ b/dotations/simulation.py
@@ -104,12 +104,9 @@ def resultfromreforms(dict_ref=None, to_compute_res=("dsr_eligible_fraction_bour
             data_convergence = DATA[[k + "_" + nom_scenario for k in ["dsr_montant_eligible_fraction_bourg_centre", "dsr_montant_eligible_fraction_perequation", "dsr_montant_hors_garanties_fraction_cible", "dsr_montant_hors_garanties_fraction_perequation", "dsr_montant_hors_garanties_fraction_bourg_centre"]]]
             data_convergence["rapport_bc"] = np.where(DATA["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario] != DATA["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + nom_scenario], DATA["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + nom_scenario] / DATA["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario], 1)
             data_convergence["rapport_pq"] = np.where(DATA["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario] != DATA["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario], DATA["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario] / DATA["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario], 1)
-            data_convergence["annee_bc"] = np.where(data_convergence["rapport_bc"] != 1, np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
-            data_convergence["annee_pq"] = np.where(data_convergence["rapport_pq"] != 1, np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
-            data_convergence["annee_bc"] = data_convergence["annee_bc"].fillna(0)
-            data_convergence["annee_pq"] = data_convergence["annee_pq"].fillna(0)          
-            # print(data_convergence)
-            # data_convergence.to_csv("blondie.csv")
+            data_convergence["annee_bc"] = np.where((data_convergence["rapport_bc"] != 1) & (data_convergence["rapport_bc"] > 0), np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
+            data_convergence["annee_pq"] = np.where((data_convergence["rapport_pq"] != 1) & (data_convergence["rapport_pq"] > 0), np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
+
             DATA["annee_convergence_dsr_" + nom_scenario] = np.maximum(data_convergence["annee_bc"], data_convergence["annee_pq"])
 
     return DATA

--- a/dotations/simulation.py
+++ b/dotations/simulation.py
@@ -108,14 +108,16 @@ def resultfromreforms(dict_ref=None, to_compute_res=("dsr_eligible_fraction_bour
         ]
         required_columns = [k + "_" + nom_scenario for k in required_variables]
         missing_columns = len([k for k in required_columns if k not in DATA.columns])
+        ZERO_FOR_FLOATS = 0.1
         if not missing_columns:
             data_convergence = DATA[[code_comm] + required_columns]
             data_convergence["rapport_bc"] = np.where(data_convergence["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario] > 0, data_convergence["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + nom_scenario] / data_convergence["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario], 1)
             data_convergence["rapport_pq"] = np.where(data_convergence["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario] > 0, data_convergence["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario] / data_convergence["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario], 1)
-            data_convergence["annee_bc"] = np.where((data_convergence["rapport_bc"] != 1) & (data_convergence["rapport_bc"] > 0.1), np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
+            # calcul des années de fin pour chaque garantie
+            data_convergence["annee_bc"] = np.where((data_convergence["rapport_bc"] != 1) & (data_convergence["rapport_bc"] > ZERO_FOR_FLOATS), np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
             data_convergence["annee_bc"] = np.where((data_convergence["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario] == 0) & (data_convergence["dsr_montant_garantie_non_eligible_fraction_bourg_centre" + "_" + nom_scenario] > 0), 2, data_convergence["annee_bc"])
             data_convergence["annee_cible"] = np.where((data_convergence["dsr_montant_garantie_non_eligible_fraction_cible" + "_" + nom_scenario] > 0), 2, 1)
-            data_convergence["annee_pq"] = np.where((data_convergence["rapport_pq"] != 1) & (data_convergence["rapport_pq"] > 0.1), np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
+            data_convergence["annee_pq"] = np.where((data_convergence["rapport_pq"] != 1) & (data_convergence["rapport_pq"] > ZERO_FOR_FLOATS), np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
             DATA["annee_convergence_dsr_" + nom_scenario] = np.maximum(np.maximum(data_convergence["annee_cible"], data_convergence["annee_bc"]), data_convergence["annee_pq"])
     return DATA
 

--- a/dotations/simulation.py
+++ b/dotations/simulation.py
@@ -97,18 +97,26 @@ def resultfromreforms(dict_ref=None, to_compute_res=("dsr_eligible_fraction_bour
         # La DSR est composée de 3 fractions, chacune d'entre elle ne peut varier que dans une certaine mesure (entre -10% et +20%)
         # Si tous les champs nécessaires au calcul sont présentes dans les résultats calculés, on inclut
         # les metrics calculées à la main
-        required_variables = ["dsr_montant_eligible_fraction_bourg_centre", "dsr_montant_eligible_fraction_perequation", "dsr_montant_hors_garanties_fraction_cible", "dsr_montant_hors_garanties_fraction_perequation", "dsr_montant_hors_garanties_fraction_bourg_centre"]
+        required_variables = [
+            "dsr_montant_eligible_fraction_bourg_centre",
+            "dsr_montant_eligible_fraction_perequation",
+            "dsr_montant_hors_garanties_fraction_cible",
+            "dsr_montant_hors_garanties_fraction_perequation",
+            "dsr_montant_hors_garanties_fraction_bourg_centre",
+            "dsr_montant_garantie_non_eligible_fraction_bourg_centre",
+            "dsr_montant_garantie_non_eligible_fraction_cible"
+        ]
         required_columns = [k + "_" + nom_scenario for k in required_variables]
         missing_columns = len([k for k in required_columns if k not in DATA.columns])
         if not missing_columns:
-            data_convergence = DATA[[k + "_" + nom_scenario for k in ["dsr_montant_eligible_fraction_bourg_centre", "dsr_montant_eligible_fraction_perequation", "dsr_montant_hors_garanties_fraction_cible", "dsr_montant_hors_garanties_fraction_perequation", "dsr_montant_hors_garanties_fraction_bourg_centre"]]]
-            data_convergence["rapport_bc"] = np.where(DATA["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario] != DATA["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + nom_scenario], DATA["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + nom_scenario] / DATA["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario], 1)
-            data_convergence["rapport_pq"] = np.where(DATA["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario] != DATA["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario], DATA["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario] / DATA["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario], 1)
-            data_convergence["annee_bc"] = np.where((data_convergence["rapport_bc"] != 1) & (data_convergence["rapport_bc"] > 0), np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
-            data_convergence["annee_pq"] = np.where((data_convergence["rapport_pq"] != 1) & (data_convergence["rapport_pq"] > 0), np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
-
-            DATA["annee_convergence_dsr_" + nom_scenario] = np.maximum(data_convergence["annee_bc"], data_convergence["annee_pq"])
-
+            data_convergence = DATA[[code_comm] + required_columns]
+            data_convergence["rapport_bc"] = np.where(data_convergence["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario] > 0, data_convergence["dsr_montant_hors_garanties_fraction_bourg_centre" + "_" + nom_scenario] / data_convergence["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario], 1)
+            data_convergence["rapport_pq"] = np.where(data_convergence["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario] > 0, data_convergence["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario] / data_convergence["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario], 1)
+            data_convergence["annee_bc"] = np.where((data_convergence["rapport_bc"] != 1) & (data_convergence["rapport_bc"] > 0.1), np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
+            data_convergence["annee_bc"] = np.where((data_convergence["dsr_montant_eligible_fraction_bourg_centre" + "_" + nom_scenario] == 0) & (data_convergence["dsr_montant_garantie_non_eligible_fraction_bourg_centre" + "_" + nom_scenario] > 0), 2, data_convergence["annee_bc"])
+            data_convergence["annee_cible"] = np.where((data_convergence["dsr_montant_garantie_non_eligible_fraction_cible" + "_" + nom_scenario] > 0), 2, 1)
+            data_convergence["annee_pq"] = np.where((data_convergence["rapport_pq"] != 1) & (data_convergence["rapport_pq"] > 0.1), np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
+            DATA["annee_convergence_dsr_" + nom_scenario] = np.maximum(np.maximum(data_convergence["annee_cible"], data_convergence["annee_bc"]), data_convergence["annee_pq"])
     return DATA
 
 

--- a/dotations/simulation.py
+++ b/dotations/simulation.py
@@ -106,6 +106,8 @@ def resultfromreforms(dict_ref=None, to_compute_res=("dsr_eligible_fraction_bour
             data_convergence["rapport_pq"] = np.where(DATA["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario] != DATA["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario], DATA["dsr_montant_hors_garanties_fraction_perequation" + "_" + nom_scenario] / DATA["dsr_montant_eligible_fraction_perequation" + "_" + nom_scenario], 1)
             data_convergence["annee_bc"] = np.where(data_convergence["rapport_bc"] != 1, np.ceil(np.maximum(np.log(data_convergence["rapport_bc"]) / np.log(0.9), np.log(data_convergence["rapport_bc"]) / np.log(1.2))), 0) + 1
             data_convergence["annee_pq"] = np.where(data_convergence["rapport_pq"] != 1, np.ceil(np.maximum(np.log(data_convergence["rapport_pq"]) / np.log(0.9), np.log(data_convergence["rapport_pq"]) / np.log(1.2))), 0) + 1
+            data_convergence["annee_bc"] = data_convergence["annee_bc"].fillna(0)
+            data_convergence["annee_pq"] = data_convergence["annee_pq"].fillna(0)          
             # print(data_convergence)
             # data_convergence.to_csv("blondie.csv")
             DATA["annee_convergence_dsr_" + nom_scenario] = np.maximum(data_convergence["annee_bc"], data_convergence["annee_pq"])


### PR DESCRIPTION
Avant :
- montant année prochaine de la DSR inclut le tunnel 90/120
- durée avant terme de la DSR inclut l'effet tunnel 90/120

Maintenant :
- montant année prochaine de la DSR inclut le tunnel 90/120  et la garantie aux communes nouvellement non éligibles pour les fractions concernées
- durée avant terme de la DSR inclut l'effet tunnel 90/120 et la garantie aux communes nouvellement non éligibles pour les fractions concernées : elle met 2 ans à atteindre 0 donc 
- Correction d'un bug qui lancait une exception dans certains cas quand de gros changements d'éligibilité avait lieu


Cette PR n'est pas dans OFDL parce que ces variables sont plus des données liées au produit leximpact que des concepts qui sont dans la loi, et que la modélisation n'est pas encore complète : d'autres types de garanties rares (et parfois pluriannuelle) ne sont pas bien modélisés dans OFDL aujourd'hui.


