### PR TITLE
Corrige une typographie dans le mail de connexion à l'application IR

### DIFF
--- a/assets/MailEmailLinkToken.html
+++ b/assets/MailEmailLinkToken.html
@@ -146,7 +146,7 @@
                                                 <tr>
                                                    <td align="left" style="font-size:0px;padding:0px 50px 0px 50px;padding-top:0px;padding-right:50px;padding-bottom:0px;padding-left:50px;word-break:break-word;">
                                                       <div style="font-family:Arial, sans-serif;font-size:13px;line-height:22px;text-align:left;color:#55575d;">
-                                                         <p style="font-size: 15px; font-family: Lato, Helvetica, Arial, sans-serif; margin: 10px 0;"><span style="font-family:Lato,Helvetica,Arial,sans-serif">Vous faîtes partie des personnes habilitées*, pour accéder au service,<br>veuillez suivre le lien ci-après :</span></p>
+                                                         <p style="font-size: 15px; font-family: Lato, Helvetica, Arial, sans-serif; margin: 10px 0;"><span style="font-family:Lato,Helvetica,Arial,sans-serif">Vous faites partie des personnes habilitées*, pour accéder au service,<br>veuillez suivre le lien ci-après :</span></p>
                                                       </div>
                                                    </td>
                                                 </tr>

--- a/tests/Simulation_engine/test_reforms_impot_revenu.py
+++ b/tests/Simulation_engine/test_reforms_impot_revenu.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from functools import lru_cache
 
 from pytest import fixture  # type: ignore

--- a/tests/server/handlers/test_dotations.py
+++ b/tests/server/handlers/test_dotations.py
@@ -1,6 +1,6 @@
 from functools import partial
 import json
-from pytest import fixture
+from pytest import fixture  # type: ignore
 
 from dotations.impact import BORNES_STRATES_DEFAULT, get_cas_types_codes_insee  # type: ignore
 from Simulation_engine.simulate_dotations import ACTIVATE_PLF  # type: ignore


### PR DESCRIPTION
Supprime un accent circonflexe identifié en LexImpact Academy dans le mail de connection à LexImpact population.
Et dit à mypy de ne pas chercher à analyser la librairie `pytest`.