### PR TITLE
Preconfigure server in pgadmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - .:/opt/leximpact-server
     depends_on:
       - postgres
+    restart: unless-stopped
 
   leximpact_client:
     build:
@@ -32,6 +33,7 @@ services:
       - /opt/leximpact-client/node_modules
     depends_on:
       - leximpact_server
+    restart: unless-stopped
 
   postgres:
     container_name: ${DATABASE_HOST:-postgres_leximpact}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-test}
     volumes:
        - pgadmin:/root/.pgadmin
+       - ./docker/pgpassfile:/pgadmin4/pgpassfile
+       - ./docker/pgadmin-servers.json:/pgadmin4/servers.json
     ports:
       - "${PGADMIN_PORT:-5050}:80"
     networks:

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ Les paramètres par défaut fonctionnent, voir le README principale pour l'expli
 ## Lancement
 
 ```sh
-docker-compose up
+docker-compose up -d
 ```
 Ceci va exécuter :
  - Postgresql sur le port 5479
@@ -28,11 +28,27 @@ Ceci va exécuter :
  - leximpact-server [http://localhost:5079](http://localhost:5079)
  - leximpact-client [http://localhost:9079](http://localhost:9079)
 
-Arrêter avec ctrl+c
 
-La base Postgres et la configuration PGAdmin sont stockées dans des volumes séparés, elles sont donc conservée après la destruction des container par :
+## Arrêt
+
+Pour arrêter :
 ```sh
 docker-compose down
+```
+
+La base Postgres et la configuration PGAdmin sont stockées dans des volumes séparés, elles sont donc conservées après la destruction des containeurs.
+
+## Voir les logs
+
+```sh
+docker logs leximpact-server_leximpact_server_1
+docker logs leximpact-server_leximpact_client_1
+```
+Ajouter '-f' à la fin de la ligne pour voir les mises à jour s'afficher. Ctrl+c pour arrêter le défillement.
+
+## Executer les tests
+```sh
+docker exec leximpact-server_leximpact_server_1 pytest
 ```
 
 ## Forcer le build

--- a/docker/pgadmin-servers.json
+++ b/docker/pgadmin-servers.json
@@ -1,0 +1,21 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "LexImpact Docker",
+            "Group": "Servers",
+            "Host": "postgres_leximpact",
+            "Port": 5432,
+            "MaintenanceDB": "postgres",
+            "Username": "leximpact-user",
+            "PassFile": "/pgadmin4/pgpassfile",
+            "SSLMode": "prefer",
+            "SSLCert": "<STORAGE_DIR>/.postgresql/postgresql.crt",
+            "SSLKey": "<STORAGE_DIR>/.postgresql/postgresql.key",
+            "SSLCompression": 0,
+            "Timeout": 10,
+            "UseSSHTunnel": 0,
+            "TunnelPort": "22",
+            "TunnelAuthentication": 0
+        }
+    }
+}

--- a/docker/pgpassfile
+++ b/docker/pgpassfile
@@ -1,0 +1,1 @@
+postgres_leximpact:5432:postgres:leximpact-user:1234leximpact


### PR DESCRIPTION
The Postgres server is now pre-configured in PGAdmin.
You just have to set the DB Password one time. Alternatively, there is a docker/pgpassfile provided but to make it work but you have to set his permission to 0600 and 5050:5050 inside the container.